### PR TITLE
refactor(wash-cli): add stop methods to test wash instance

### DIFF
--- a/crates/providers/Cargo.lock
+++ b/crates/providers/Cargo.lock
@@ -2379,9 +2379,9 @@ checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.36.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae0be20bf87918df4fa831bfbbd0b491d24aee407ed86360eae4c2c5608d38"
+checksum = "7d135e8940b69dbee0f5b0a0be9c1cd6fa8b71d774904c13a3fcfc5dc265e43d"
 dependencies = [
  "leb128",
 ]

--- a/crates/wash-cli/.gitignore
+++ b/crates/wash-cli/.gitignore
@@ -1,0 +1,1 @@
+tests/output

--- a/crates/wash-cli/tests/wash_stop.rs
+++ b/crates/wash-cli/tests/wash_stop.rs
@@ -2,10 +2,9 @@ mod common;
 
 use common::{TestWashInstance, ECHO_OCI_REF, PROVIDER_HTTPSERVER_OCI_REF};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serial_test::serial;
-use tokio::process::Command;
-use wash_lib::cli::output::{StartCommandOutput, StopCommandOutput};
+use wash_lib::cli::output::StartCommandOutput;
 
 #[tokio::test]
 #[serial]
@@ -16,59 +15,24 @@ use wash_lib::cli::output::{StartCommandOutput, StopCommandOutput};
 async fn integration_stop_actor_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "start",
-            "actor",
-            ECHO_OCI_REF,
-            "--output",
-            "json",
-            "--timeout-ms",
-            "20000",
-            "--ctl-port",
-            &wash_instance.nats_port.to_string(),
-        ])
-        .output()
-        .await
-        .context("failed to start actor")?;
-    assert!(output.status.success(), "executed start");
-
     let StartCommandOutput {
         actor_id,
         actor_ref,
         host_id,
         success,
         ..
-    } = serde_json::from_slice(&output.stdout).context("failed to parse start output")?;
+    } = wash_instance.start_actor(ECHO_OCI_REF).await?;
     assert!(success, "start command returned success");
+
     let actor_id = actor_id.expect("missing actor_id from start command output");
     let actor_ref = actor_ref.expect("missing actor_ref from start command output");
     assert_eq!(actor_ref, ECHO_OCI_REF, "actor ref matches");
+
     let host_id = host_id.expect("missing host_id from start command output");
     assert_eq!(host_id, wash_instance.host_id, "host_id matches");
 
     // Stop the actor
-    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "stop",
-            "actor",
-            "--host-id",
-            &host_id,
-            &actor_id,
-            "--output",
-            "json",
-            "--ctl-port",
-            &wash_instance.nats_port.to_string(),
-        ])
-        .output()
-        .await
-        .context("failed to stop actor")?;
-
-    assert!(output.status.success(), "executed stop");
-
-    let cmd_output: StopCommandOutput =
-        serde_json::from_slice(&output.stdout).context("failed to parse stop output")?;
-    assert!(cmd_output.success, "command returned success");
+    wash_instance.stop_actor(&actor_id, Some(host_id)).await?;
 
     Ok(())
 }
@@ -78,23 +42,6 @@ async fn integration_stop_actor_serial() -> Result<()> {
 async fn integration_stop_provider_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "start",
-            "provider",
-            PROVIDER_HTTPSERVER_OCI_REF,
-            "--output",
-            "json",
-            "--timeout-ms",
-            "20000",
-            "--ctl-port",
-            &wash_instance.nats_port.to_string(),
-        ])
-        .output()
-        .await
-        .context("failed to start actor")?;
-    assert!(output.status.success(), "executed start");
-
     let StartCommandOutput {
         provider_id,
         provider_ref,
@@ -103,42 +50,27 @@ async fn integration_stop_provider_serial() -> Result<()> {
         contract_id,
         success,
         ..
-    } = serde_json::from_slice(&output.stdout).context("failed to parse start output")?;
+    } = wash_instance
+        .start_provider(PROVIDER_HTTPSERVER_OCI_REF)
+        .await?;
     assert!(success, "start command returned success");
+
     let provider_ref = provider_ref.expect("missing provider_ref from start command output");
     assert_eq!(
         provider_ref, PROVIDER_HTTPSERVER_OCI_REF,
         "provider ref matches"
     );
+
     let provider_id = provider_id.expect("missing provider_id from start command output");
     let host_id = host_id.expect("missing host_id from start command output");
     assert_eq!(host_id, wash_instance.host_id, "host_id matches");
+
     let link_name = link_name.expect("missing link_name from start command output");
     let contract_id = contract_id.expect("missing contract_id from start command output");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "stop",
-            "provider",
-            "--host-id",
-            &host_id,
-            &provider_id,
-            &contract_id,
-            &link_name,
-            "--output",
-            "json",
-            "--ctl-port",
-            &wash_instance.nats_port.to_string(),
-        ])
-        .output()
-        .await
-        .context("failed to stop provider")?;
-
-    assert!(output.status.success(), "executed stop");
-
-    let cmd_output: StopCommandOutput =
-        serde_json::from_slice(&output.stdout).context("failed to parse stop output")?;
-    assert!(cmd_output.success, "command returned success");
+    wash_instance
+        .stop_provider(&provider_id, &contract_id, Some(host_id), Some(link_name))
+        .await?;
 
     Ok(())
 }
@@ -147,26 +79,6 @@ async fn integration_stop_provider_serial() -> Result<()> {
 #[serial]
 async fn integration_stop_host_serial() -> Result<()> {
     let wash_instance = TestWashInstance::create().await?;
-
-    let output = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "stop",
-            "host",
-            &wash_instance.host_id,
-            "--output",
-            "json",
-            "--ctl-port",
-            &wash_instance.nats_port.to_string(),
-        ])
-        .output()
-        .await
-        .context("failed to stop provider")?;
-
-    assert!(output.status.success(), "executed stop");
-
-    let cmd_output: StopCommandOutput =
-        serde_json::from_slice(&output.stdout).context("failed to parse output")?;
-    assert!(cmd_output.success, "command returned success");
-
+    wash_instance.stop_host().await?;
     Ok(())
 }


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

`TestWashInstance` is a test utility struct that encapsulates (and tracks) child processes spawned by `wash` so that they can be cleaned up upon `drop()`, and information about spawned hosts can be retrieved.

Some invocations of `wash` itself (normally from tests that ensure functionality works have been moved into `TestWashInstance` to make them easier to call -- with the *current* built version of `wash` (i.e. the cargo-provided ENV variable `CARGO_BIN_EXE_wash`).

This commit adds more invocations (`wash start provider`, `wash stop actor`, `wash stop host`) into the `TestWashInstance` struct used from tests, shortening the code required for individual tests.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
