### PR TITLE
feat(providers): add sqldb-postgres provider

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -56,6 +56,8 @@ on:
       - 'provider-messaging-kafka-v[0-9].[0-9]+.[0-9]+-*'
       - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+'
       - 'provider-messaging-nats-v[0-9].[0-9]+.[0-9]+-*'
+      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+'
+      - 'provider-sqldb-postgres-v[0-9].[0-9]+.[0-9]+-*'
       - 'provider-sdk-v[0-9].[0-9]+.[0-9]+'
       - 'provider-sdk-v[0-9].[0-9]+.[0-9]+-*'
       - 'runtime-v[0-9].[0-9]+.[0-9]+'
@@ -172,6 +174,7 @@ jobs:
       - run: move "target/release/lattice-controller-provider.exe" "artifact/bin/lattice-controller-provider.exe"
       - run: move "target/release/messaging-kafka-provider.exe" "artifact/bin/messaging-kafka-provider.exe"
       - run: move "target/release/messaging-nats-provider.exe" "artifact/bin/messaging-nats-provider.exe"
+      - run: move "target/release/sqldb-postgres-provider.exe" "artifact/bin/sqldb-postgres-provider.exe"
 
       - run: move "target/release/wash.exe" "artifact/bin/wash.exe"
       - run: move "target/release/wasmcloud.exe" "artifact/bin/wasmcloud.exe"
@@ -305,6 +308,9 @@ jobs:
 
           - name: messaging-nats
             subject: MESSAGING_NATS_SUBJECT
+
+          - name: sqldb-postgres
+            subject: SQLDB_POSTGRES_SUBJECT
 
     needs:
       - build-bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "once_cell",
  "serde",
  "version_check",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "ambient-authority"
@@ -94,47 +94,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -156,6 +157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +176,12 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "ascii_tree"
@@ -235,7 +251,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "rustls-webpki 0.101.7",
@@ -260,7 +276,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -325,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
@@ -346,7 +362,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "http 0.2.12",
  "hyper 0.14.28",
  "time",
@@ -382,20 +398,20 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc5ce518d4b8d16e0408de7bdf1b3097cec61a7daa979750a208f8d9934386d"
+checksum = "91303c2fed0fc851059edd5a3c69cc139197bf41accbaab9cfd60b2410647a0e"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -412,7 +428,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -428,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7207ca62206c93e470457babf0512d7b6b97170fdba929a2a2f5682f9f68407c"
+checksum = "9e2b4a632a59e4fab7abf1db0d94a3136ad7871aba46bebd1fdb95c7054afcdb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -567,7 +583,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -577,7 +593,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -761,7 +777,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-pemfile 2.1.2",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -780,7 +796,7 @@ dependencies = [
  "bytes",
  "dyn-clone",
  "futures",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "http-types",
  "once_cell",
  "paste",
@@ -794,7 +810,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -813,7 +829,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -834,7 +850,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -909,6 +925,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bcder"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,9 +1021,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "byteorder"
@@ -1145,12 +1195,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1171,8 +1222,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "cidr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
 
 [[package]]
 name = "claims"
@@ -1223,7 +1280,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1247,21 +1304,21 @@ dependencies = [
  "serde_json",
  "snafu",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "web-sys",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
-version = "4.6.6"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1373,7 +1430,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "log",
  "regalloc2",
  "smallvec",
@@ -1555,7 +1612,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1603,7 +1660,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1625,7 +1682,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1635,7 +1692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1646,6 +1703,39 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19be9da496d60d03ec3ab45d960d80a3afb285b787394b83614a79942f467e7f"
+dependencies = [
+ "deadpool",
+ "getrandom 0.2.15",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "delegate-attr"
@@ -1836,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "encode_unicode"
@@ -1848,9 +1938,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1863,9 +1953,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1886,6 +1976,16 @@ name = "escape_string"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
+
+[[package]]
+name = "eui48"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887418ac5e8d57c2e66e04bdc2fe15f9a5407be20b54a82c86bd0e368b709701"
+dependencies = [
+ "regex",
+ "rustc-serialize",
+]
 
 [[package]]
 name = "event-listener"
@@ -1916,6 +2016,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1941,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fd-lock"
@@ -1958,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1975,10 +2081,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.28"
+name = "finl_unicode"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2006,7 +2118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -2100,7 +2212,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2144,6 +2256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2173,7 +2296,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap 2.2.6",
  "stable_deref_trait",
 ]
@@ -2272,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2527,7 +2650,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2568,15 +2691,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736f15a50e749d033164c56c09783b6102c4ff8da79ad77dbddbbaea0f8567f7"
+checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
- "rustls 0.23.4",
+ "rustls 0.23.5",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2693,7 +2816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2782,6 +2905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "iso8601"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,9 +2945,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -2845,7 +2974,7 @@ dependencies = [
  "clap",
  "fancy-regex",
  "fraction",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "iso8601",
  "itoa",
  "memchr",
@@ -2859,7 +2988,7 @@ dependencies = [
  "serde_json",
  "time",
  "url",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -2920,9 +3049,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -2942,9 +3077,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2962,7 +3097,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3118,7 +3253,7 @@ dependencies = [
  "data-encoding",
  "ed25519",
  "ed25519-dalek",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "log",
  "rand 0.8.5",
  "signatory",
@@ -3201,25 +3336,37 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
- "num-bigint",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.2",
  "num-traits",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3232,9 +3379,19 @@ checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -3256,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3267,11 +3424,21 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3279,11 +3446,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3318,7 +3486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "memchr",
 ]
@@ -3528,9 +3696,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3538,22 +3706,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-absolutize"
@@ -3586,6 +3754,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,9 +3780,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3625,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3635,26 +3813,57 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pg_bigdecimal"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9855a94c74528af62c0ea236577af5e601263c1c404a6ac939b07c97c8e0216"
+dependencies = [
+ "bigdecimal 0.3.1",
+ "byteorder 1.5.0",
+ "bytes",
+ "num 0.4.3",
+ "postgres",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3674,7 +3883,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3716,6 +3925,59 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "postgres"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder 1.5.0",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "array-init",
+ "bit-vec",
+ "bytes",
+ "chrono",
+ "cidr",
+ "eui48",
+ "fallible-iterator 0.2.0",
+ "geo-types",
+ "postgres-protocol",
+ "serde",
+ "serde_json",
+ "uuid 0.8.2",
+ "uuid 1.8.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3767,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3899,7 +4161,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3978,12 +4240,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -4074,7 +4345,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4145,7 +4416,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -4154,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddb316f4b9cae1a3e89c02f1926d557d1142d0d2e684b038c11c1b77705229a"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder 1.5.0",
  "num-traits",
@@ -4165,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a142ab806f18b88a97b0dea523d39e0fd730a064b035726adcfc58a8a5188"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
  "byteorder 1.5.0",
  "rmp",
@@ -4176,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "rmpv"
-version = "1.0.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e540282f11751956c82bc5529a7fb71b871b998fbf9cf06c2419b22e1b4350df"
+checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
 dependencies = [
  "num-traits",
  "rmp",
@@ -4206,15 +4477,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc_version"
@@ -4247,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "rustify_derive"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58135536c18c04f4634bedad182a3f41baf33ef811cc38a3ec7b7061c57134c8"
+checksum = "7345f32672da54338227b727bd578c897859ddfaad8952e0b0d787fb4e58f07d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4261,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4276,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -4295,21 +4572,21 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
@@ -4360,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -4376,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4387,15 +4664,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -4449,11 +4726,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4462,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4524,7 +4801,7 @@ checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4566,7 +4843,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4609,7 +4886,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4688,9 +4965,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -4722,6 +4999,12 @@ name = "simple_env_load"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062f063a8bb8336fa98ee0eae53115bf6753ca9c83437808bf000c65621ca5e3"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -4767,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4813,6 +5096,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,7 +5234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -4998,7 +5292,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5009,7 +5303,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "test-case-core",
 ]
 
@@ -5030,7 +5324,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5127,7 +5421,47 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder 1.5.0",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.8.5",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
+dependencies = [
+ "ring",
+ "rustls 0.23.5",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.0",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -5147,7 +5481,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -5168,7 +5502,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.4",
+ "rustls 0.23.5",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5242,7 +5576,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -5269,15 +5603,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -5376,7 +5710,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5468,7 +5802,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "web-time 1.1.0",
 ]
@@ -5511,9 +5845,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -5559,11 +5893,17 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "serde",
 ]
@@ -5635,15 +5975,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "uuid",
+ "uuid 1.8.0",
  "wasmcloud-control-interface 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -5872,6 +6212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5892,7 +6238,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -5926,7 +6272,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6033,7 +6379,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "vaultrs",
  "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0",
@@ -6050,6 +6396,7 @@ dependencies = [
  "wasmcloud-provider-messaging-kafka",
  "wasmcloud-provider-messaging-nats",
  "wasmcloud-provider-sdk",
+ "wasmcloud-provider-sqldb-postgres",
  "wasmcloud-test-util",
  "wasmcloud-tracing",
  "wrpc-interface-http",
@@ -6067,7 +6414,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tokio",
- "uuid",
+ "uuid 1.8.0",
  "wit-bindgen",
 ]
 
@@ -6149,7 +6496,7 @@ dependencies = [
  "hex",
  "nkeys",
  "once_cell",
- "rustls 0.23.4",
+ "rustls 0.23.5",
  "serde",
  "serde_bytes",
  "sha2",
@@ -6157,7 +6504,7 @@ dependencies = [
  "tower",
  "tracing",
  "ulid",
- "uuid",
+ "uuid 1.8.0",
  "wascap 0.13.0",
  "wrpc-transport",
  "wrpc-transport-nats",
@@ -6173,13 +6520,13 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
- "hyper-rustls 0.27.0",
+ "hyper-rustls 0.27.1",
  "hyper-util",
  "nkeys",
  "oci-distribution",
  "once_cell",
  "reqwest 0.12.4",
- "rustls 0.23.4",
+ "rustls 0.23.5",
  "rustls-native-certs 0.7.0",
  "serde",
  "serde_bytes",
@@ -6188,7 +6535,7 @@ dependencies = [
  "tower",
  "tracing",
  "ulid",
- "uuid",
+ "uuid 1.8.0",
  "wascap 0.14.0",
  "webpki-roots 0.26.1",
  "wrpc-transport",
@@ -6226,7 +6573,7 @@ dependencies = [
  "tracing",
  "ulid",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "wascap 0.14.0",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-core 0.6.0",
@@ -6327,7 +6674,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "futures",
- "hyper-rustls 0.27.0",
+ "hyper-rustls 0.27.1",
  "hyper-util",
  "tokio",
  "tracing",
@@ -6372,7 +6719,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "wasmcloud-control-interface 1.0.0",
  "wasmcloud-provider-sdk",
  "wasmcloud-test-util",
@@ -6466,7 +6813,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "ulid",
- "uuid",
+ "uuid 1.8.0",
  "wasmcloud-core 0.6.0",
  "wasmcloud-tracing",
  "wrpc-interface-blobstore",
@@ -6474,6 +6821,35 @@ dependencies = [
  "wrpc-transport",
  "wrpc-transport-nats",
  "wrpc-types",
+]
+
+[[package]]
+name = "wasmcloud-provider-sqldb-postgres"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bigdecimal 0.4.3",
+ "bit-vec",
+ "bytes",
+ "chrono",
+ "cidr",
+ "deadpool-postgres",
+ "eui48",
+ "futures",
+ "geo-types",
+ "num 0.2.1",
+ "pg_bigdecimal",
+ "postgres-types",
+ "rustls 0.23.5",
+ "serde_json",
+ "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
+ "tracing",
+ "ulid",
+ "uuid 1.8.0",
+ "wasmcloud-provider-sdk",
+ "wit-bindgen-wrpc",
 ]
 
 [[package]]
@@ -6496,7 +6872,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.8.0",
  "wascap 0.14.0",
  "wasmcloud-actor",
  "wasmcloud-component-adapters",
@@ -6665,7 +7041,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -6807,7 +7183,7 @@ checksum = "0d3b70422fdfa915c903f003b8b42554a8ae1aa0c6208429d8314ebf5721f3ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7002,6 +7378,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall 0.4.1",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7019,11 +7406,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7055,7 +7442,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -7073,7 +7460,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -7093,17 +7480,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -7114,9 +7502,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7126,9 +7514,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7138,9 +7526,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7150,9 +7544,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7162,9 +7556,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7174,9 +7568,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7186,9 +7580,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -7201,9 +7595,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -7316,7 +7710,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7358,7 +7752,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
  "wit-bindgen-core",
  "wit-bindgen-wrpc-rust",
 ]
@@ -7498,6 +7892,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-certificate"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7505,22 +7918,22 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7528,6 +7941,20 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ providers = [
     "dep:wasmcloud-provider-lattice-controller",
     "dep:wasmcloud-provider-messaging-kafka",
     "dep:wasmcloud-provider-messaging-nats",
+    "dep:wasmcloud-provider-sqldb-postgres",
     "dep:wasmcloud-provider-sdk",
 ]
 default = ["providers"]
@@ -77,6 +78,10 @@ required-features = ["providers"]
 name = "messaging-nats-provider"
 required-features = ["providers"]
 
+[[bin]]
+name = "sqldb-postgres-provider"
+required-features = ["providers"]
+
 [profile.release]
 strip = true
 opt-level = "z"
@@ -110,6 +115,7 @@ wasmcloud-provider-keyvalue-vault = { workspace = true, optional = true }
 wasmcloud-provider-lattice-controller = { workspace = true, optional = true }
 wasmcloud-provider-messaging-kafka = { workspace = true, optional = true }
 wasmcloud-provider-messaging-nats = { workspace = true, optional = true }
+wasmcloud-provider-sqldb-postgres = { workspace = true, optional = true }
 wasmcloud-provider-sdk = { workspace = true, features = [
     "otel",
 ], optional = true }
@@ -179,6 +185,8 @@ axum-server = { version = "0.6", default-features = false }
 azure_core = { version = "0.20", default-features = false }
 azure_storage = { version = "0.20", default-features = false }
 azure_storage_blobs = { version = "0.20", default-features = false }
+bigdecimal = { version = "0.4", default-features = false }
+bit-vec = { version = "0.6", default-features = false }
 base64 = { version = "0.22", default-features = false }
 bytes = { version = "1", default-features = false }
 cap-std = { version = "3", default-features = false }
@@ -186,6 +194,7 @@ cargo_metadata = { version = "0.18", default-features = false }
 cargo_toml = { version = "0.15", default-features = false }
 cbindgen = { version = "0.25", default-features = false }
 chrono = { version = "0.4", default-features = false }
+cidr = { version = "0.2", default-features = false }
 claims = { version = "0.7", default-features = false }
 clap = { version = "4", default-features = false }
 clap_complete = { version = "4", default-features = false }
@@ -195,9 +204,12 @@ config = { version = "0.13", default-features = false }
 console = { version = "0.15", default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", default-features = false }
+deadpool-postgres = { version = "0.13", default-features = false }
 dialoguer = { version = "0.10", default-features = false }
 dirs = { version = "4", default-features = false }
+eui48 = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
+geo-types = { version = "0.7", default-features = false }
 heck = { version = "0.5", default-features = false }
 hex = { version = "0.4", default-features = false }
 http = { version = "1", default-features = false, features = ["std"] }
@@ -215,6 +227,7 @@ nkeys = { version = "0.3", default-features = false }
 normpath = { version = "1", default-features = false }
 notify = { version = "6", default-features = false }
 nuid = { version = "0.4", default-features = false }
+num = { version = "0.2", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
 once_cell = { version = "1", default-features = false }
 opentelemetry = { version = "0.21", default-features = false }
@@ -224,6 +237,8 @@ opentelemetry-otlp = { version = "0.14", default-features = false }
 opentelemetry_sdk = { version = "0.21", default-features = false }
 path-absolutize = { version = "3", default-features = false }
 path-clean = { version = "1", default-features = false }
+pg_bigdecimal = { version = "0.1", default-features = false }
+postgres-types = { version = "0.2", default-features = false }
 provider-archive = { version = "^0.10.2", path = "./crates/provider-archive", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
@@ -258,6 +273,8 @@ test-case = { version = "3", default-features = false }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false }
 tokio = { version = "1", default-features = false }
+tokio-postgres = { version = "0.7", default-features = false }
+tokio-postgres-rustls = { version = "0.12", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-tar = { version = "0.3", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
@@ -296,6 +313,7 @@ wasmcloud-provider-lattice-controller = { version = "*", path = "./crates/provid
 wasmcloud-provider-messaging-kafka = { version = "*", path = "./crates/provider-messaging-kafka", default-features = false }
 wasmcloud-provider-messaging-nats = { version = "*", path = "./crates/provider-messaging-nats", default-features = false }
 wasmcloud-provider-sdk = { version = "^0.5.0", path = "./crates/provider-sdk", default-features = false }
+wasmcloud-provider-sqldb-postgres = { version = "*", path = "./crates/provider-sqldb-postgres", default-features = false }
 wasmcloud-runtime = { version = "0", path = "./crates/runtime", default-features = false }
 wasmcloud-test-util = { version = "^0.2.0", path = "./crates/test-util", default-features = false }
 wasmcloud-tracing = { version = "^0.4.0", path = "./crates/tracing", default-features = false }

--- a/crates/provider-sqldb-postgres/.gitignore
+++ b/crates/provider-sqldb-postgres/.gitignore
@@ -1,0 +1,3 @@
+build
+target
+.idea

--- a/crates/provider-sqldb-postgres/Cargo.toml
+++ b/crates/provider-sqldb-postgres/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "wasmcloud-provider-sqldb-postgres"
+version = "0.1.0"
+description = """
+wasmCloud SQL database provider for Postgres
+"""
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = [ "rustls" ]
+rustls = [ "dep:tokio-postgres-rustls" ]
+
+[dependencies]
+anyhow = { workspace = true }
+bigdecimal = { workspace = true }
+bit-vec = { workspace = true, features = [ "std" ] }
+bytes = { workspace = true }
+chrono = { workspace = true, features = [ "std" ] }
+cidr = { workspace = true, features = [ "std" ] }
+deadpool-postgres = { workspace = true, features = [ "rt_tokio_1" ] }
+eui48 = { workspace = true }
+futures = { workspace = true }
+geo-types = { workspace = true }
+num = { workspace = true }
+pg_bigdecimal = { workspace = true }
+postgres-types = { workspace = true, features = [ "with-cidr-0_2" ] }
+rustls = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-postgres = { workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ]  }
+tokio-postgres-rustls = { workspace = true, optional = true }
+tracing = { workspace = true }
+ulid = { workspace = true }
+uuid = { workspace = true }
+wasmcloud-provider-sdk = { workspace = true, features = ["otel"] }
+wit-bindgen-wrpc = { workspace = true }
+ 

--- a/crates/provider-sqldb-postgres/README.md
+++ b/crates/provider-sqldb-postgres/README.md
@@ -1,0 +1,180 @@
+# 🐘 SQL Database Postgres Provider
+
+This capability provider implements the [wasmcloud:sqldb-postgres](https://github.com/wasmCloud/interfaces/tree/main/keyvalue) WIT package, which enables SQL-driven database interaction with a [Postgres][postgres] database cluster.
+
+This provider handles concurrent component connections, and components can choose how they manage connections:
+
+| Management type    | Description                                                       |
+|--------------------|-------------------------------------------------------------------|
+| Completely Managed | Defined at provider startup via host-supplied named configuration |
+| Link Driven        | Defined via config for each component-provider link               |
+| Component Driven   | Controlled completely by connected components                     |
+
+This means that components can either use a simple interface to perform requests, relying on pre-established configuration for determining what database/connection/session information to use, *or*  create their own connections, managed by the provider.
+
+Want to read all the functionality included the interface? [Start from `provider.wit`](./wit/provider.wit) to read what this provider can do, and work your way to [`types.wit`](./wit/types.wit).
+
+Note that connections are local to a single provider, so multiple providers running on the same lattice will *not* share connections automatically.
+
+[postgres]: https://postgresql.org
+
+## 👟 Quickstart
+
+To get this provider started quickly, you can start with:
+
+```console
+wash start provider ghcr.io/wasmcloud/provider-sqldb-postgres:0.1.0
+```
+
+The easiest way to start a Postgres provider with configuration specified, and a component that uses it is with [wasmCloud Application Deployment Manager][wadm]. 
+
+<details>
+<summary>Example manifest for an HTTP server with a database connection</summary>
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: sqldb-postgres-example
+  annotations:
+    version: v0.0.1
+    description:  SQLDB Postgres example
+spec:
+  components:
+    # A capability provider that enables Postgres access for the component
+    - name: sqldb-postgres
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/sqldb-postgres:0.1.0
+        config: 
+          # NOTE: Since this is a named configuration provided by the host,
+          # you'll need to make sure it exists *before* deploying this manifest!
+          #
+          # see: `wash config put`
+          - name: default-postgres
+
+    # A capability provider that provides HTTP serving for the component
+    - name: http-server
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.20.0
+
+    # A component that uses both capability providers above (HTTP server and sqldb-postgres)
+    # to provide a TODO app on http://localhost:8080
+    - name: todo-app
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-todoapp-postgres-rust:0.1.0
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            replicas: 1
+
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
+        - type: link
+          properties:
+            target: http-server
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+
+        # Link the sqldb-provider to the component, specifying the postgres cluster URL
+        - type: link
+          properties:
+            target: sqldb-postgres
+            namespace: wasmcloud
+            package: sqldb-postgres
+            interfaces: [migrations, managed-raw, managed-prepared]
+            target_config:
+              - name: pg
+                properties:
+                  url: postgres://127.0.0.1:5432
+```
+
+</details>
+
+[wadm]: https://github.com/wasmCloud/wadm
+
+
+## 📑 Named configuration Settings
+
+As connection details are considered sensitive information, they should be specified via named config available to the provider *at startup*, rather than via link definitions.
+
+> ![NOTE]
+> Named configuration can be specified by:
+>
+> - Using appropriate options on `wash config put`
+
+| Property                      | Example                     | Description                                                                |
+|-------------------------------|-----------------------------|----------------------------------------------------------------------------|
+| `MANAGED_URL`                 | `postgres://localhost:5432` | URL to use for all managed connections (overrides `*_HOST`, `*_PORT`, etc) |
+| `MANAGED_HOST`                | `localhost`                 | Hostname for all managed connections                                       |
+| `MANAGED_PORT`                | `5432`                      | Port for all managed connections                                           |
+| `MANAGED_USERNAME`            | `postgres`                  | Username for all managed connections                                       |
+| `MANAGED_PASSWORD`            | `postgres`                  | Password for all managed connections                                       |
+| `MANAGED_TLS_REQUIRED`        | `false`                     | Whether TLS should be required for al managed connections                  |
+| `PROFILE_<name>_URL`          | `postgres://some-db:5432`   | URL to use for all named profile connection `<name>`                       |
+| `PROFILE_<name>_HOST`         | `localhost`                 | Hostname to use for named profile connection `<name>`                      |
+| `PROFILE_<name>_PORT`         | `5432`                      | Port to use for named profile connection `<name>`                          |
+| `PROFILE_<name>_USERNAME`     | `postgres`                  | Username to use for named profile connection `<name>`                      |
+| `PROFILE_<name>_PASSWORD`     | `postgres`                  | Password to use for named profile connection `<name>`                      |
+| `PROFILE_<name>_TLS_REQUIRED` | `false`                     | Whether to require TLS for named profile connection `<name>`               |
+
+> ![NOTE]
+> As multiple components will connect to the same provider, the primary method of configuring connection "profiles" is via ENV variables
+> that are prefixed with `PROFILE_<name of profile>`.
+>
+> For example, to create a minimal working profile named `demo`, the named configuration value `PROFILE_demo_URL=localhost:5432` is all you need
+
+If you have many profiles, you may want to contain them in a single JSON file available at a secure (possibly bindmounted) location on disk, and present that path to the provider via the named configuration variable `PROFILES_JSON_DIR_PATH`. Only the *first* level of files beneath the directory will be processed.
+
+An example of a minimally valid JSON file representing a profile (ex. `demo.json`):
+
+```json
+{
+  "url": "localhost:5432"
+}
+```
+
+## 🔗 Link Definition Configuration Settings
+
+The following is a list of configuration settings you can specify on *each link* (i.e. commonly `target_config`in a WADM manifest) for this provider.
+
+> ![NOTE]
+> Link definition configuration can be specified by:
+>
+> - Writing a WADM manifest with proper `link` traits (with `source_config`/`target_config` values)
+> - Using appropriate options on `wash link put`
+
+| Property             | Example | Description                                        |
+|----------------------|---------|----------------------------------------------------|
+| `CONNECTION_PROFILE` | `demo`  | Name of the connection profile that should be used |
+
+# 🛠️ Development
+
+## 📦 Building a PAR
+
+To build a [Provider Archive (`.par`/`.par.gz`)][par] for this provider, first build the project with `wash`:
+
+```console
+wash build
+```
+
+Then run `wash par`:
+
+```
+wash par create \
+  --compress
+  --binary target/debug/sqldb-postgres-provider
+  --vendor wasmcloud
+  --version 0.1.0
+  --name sqldb-postgres-provider`
+```
+
+[par]: https://wasmcloud.com/docs/developer/providers/build

--- a/crates/provider-sqldb-postgres/src/bindings.rs
+++ b/crates/provider-sqldb-postgres/src/bindings.rs
@@ -1,0 +1,1114 @@
+//! This module contains generated bindings, and code to make bindings more ergonomic
+//!
+
+// todo(refactor): most of the utils/impl in this file should essentially turn into
+// `wasi-ext-wasmcloud-postgres`, and be usable from both components, providers, and
+// any other WASI ecosystem tools that rely on this WIT contract.
+
+use core::hash::{Hash, Hasher};
+use core::net::IpAddr;
+use std::collections::HashMap;
+use std::error::Error;
+use std::hash::DefaultHasher;
+use std::str::FromStr;
+
+use anyhow::{bail, Context as _};
+use bigdecimal::num_traits::Float;
+use bit_vec::BitVec;
+use bytes::BytesMut;
+use chrono::{
+    DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset as _, Timelike,
+    Utc,
+};
+use cidr::IpCidr;
+use eui48::MacAddress;
+use geo_types::{coord, LineString, Point, Rect};
+use pg_bigdecimal::PgNumeric;
+use postgres_types::{FromSql, IsNull, PgLsn, ToSql, Type as PgType};
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+use crate::{managed_connection_token_id, named_profile_connection_token_id};
+
+// Bindgen happens here
+wit_bindgen_wrpc::generate!({
+  additional_derives: [PartialEq, Eq, Hash, Clone],
+});
+
+// Start bindgen-generated type imports
+pub(crate) use exports::wasmcloud::postgres::connection;
+pub(crate) use exports::wasmcloud::postgres::managed_query;
+pub(crate) use exports::wasmcloud::postgres::prepared;
+pub(crate) use exports::wasmcloud::postgres::query;
+
+pub(crate) use connection::{
+    ConnectionCreateOptions, ConnectionOptions, ConnectionToken, CreateConnectionError,
+};
+
+pub(crate) use managed_query::{PgValue, QueryError, ResultRow};
+
+pub(crate) use prepared::{
+    PreparedStatementExecError, PreparedStatementToken, StatementPrepareError,
+};
+
+use crate::bindings::wasmcloud::postgres::types::{
+    Date, HashableF64, Numeric, Offset, ResultRowEntry, Time, Timestamp, TimestampTz,
+};
+// End of bindgen-generated type imports
+
+/// Build an `f64` from a mantissa, exponent and sign
+fn f64_from_components(mantissa: u64, exponent: i16, sign: i8) -> f64 {
+    let sign_f = sign as f64;
+    let mantissa_f = mantissa as f64;
+    let exponent_f = 2f64.powf(exponent as f64);
+    sign_f * mantissa_f * exponent_f
+}
+
+/// Build an `f64` from a simple tuple of mantissa, exponent and sign
+fn f64_from_tuple(t: &(u64, i16, i8)) -> f64 {
+    f64_from_components(t.0, t.1, t.2)
+}
+
+/// Convert [`Rect`] which *should* contain points for two opposite corners into
+/// a tuple of points (AKA two `HashableF64`s)
+fn rect_to_hashable_f64s(r: Rect<f64>) -> ((HashableF64, HashableF64), (HashableF64, HashableF64)) {
+    let (bottom_left_x, bottom_left_y) = r.min().x_y();
+    let (top_right_x, top_right_y) = r.max().x_y();
+    (
+        (
+            bottom_left_x.integer_decode(),
+            bottom_left_y.integer_decode(),
+        ),
+        (top_right_x.integer_decode(), top_right_y.integer_decode()),
+    )
+}
+
+/// Convert a [`Linestring`] which represents a line/line segment and is expected to
+/// contain only *two* points, into a tuple of `HashableF64`s
+fn linestring_to_hashable_f64s_tuple(
+    l: LineString<f64>,
+) -> anyhow::Result<((HashableF64, HashableF64), (HashableF64, HashableF64))> {
+    match linestring_to_hashable_f64s(l)[..] {
+        [start, end] => Ok((start, end)),
+        _ => bail!("unexpected number of points in line string"),
+    }
+}
+
+/// Convert a [`Linestring`] into a vector of points (AKA two bindgen-generated `HashableF64`s)
+fn linestring_to_hashable_f64s(l: LineString<f64>) -> Vec<(HashableF64, HashableF64)> {
+    l.into_points()
+        .into_iter()
+        .map(point_to_hashable_f64s)
+        .collect::<Vec<_>>()
+}
+
+/// Convert a [`Point`] into two bindgen-generated `HashableF64`s
+fn point_to_hashable_f64s(p: Point<f64>) -> (HashableF64, HashableF64) {
+    let (x, y) = p.x_y();
+    (x.integer_decode(), y.integer_decode())
+}
+
+/// Convert a list of bytes to a MacAddress
+fn bytes_to_macaddr(bytes: impl AsRef<[u8]>) -> anyhow::Result<PgValue> {
+    let bytes = bytes.as_ref();
+    match bytes {
+        [octet0, octet1, octet2, octet3, octet4, octet5] => Ok(PgValue::Macaddr((
+            *octet0, *octet1, *octet2, *octet3, *octet4, *octet5,
+        ))),
+        _ => bail!("unexpected number of bytes in received macaddress"),
+    }
+}
+
+/// Convert a 6 byte MacAddress to a tuple of bytes
+fn macaddr_to_bytes(m: MacAddress) -> anyhow::Result<(u8, u8, u8, u8, u8, u8)> {
+    match m.as_bytes() {
+        [octet0, octet1, octet2, octet3, octet4, octet5] => {
+            Ok((*octet0, *octet1, *octet2, *octet3, *octet4, *octet5))
+        }
+        _ => bail!("unexpected number of bytes in received macaddress"),
+    }
+}
+
+impl TryFrom<MacAddress> for PgValue {
+    type Error = anyhow::Error;
+
+    fn try_from(m: MacAddress) -> anyhow::Result<PgValue> {
+        match m.as_bytes() {
+            bytes if bytes.len() == 8 => bytes_to_macaddr8(bytes),
+            bytes if bytes.len() == 6 => bytes_to_macaddr(bytes),
+            _ => bail!("unexpected number of bytes in macaddress"),
+        }
+    }
+}
+
+/// Convert a list of bytes to a MacAddress8
+fn bytes_to_macaddr8(bytes: impl AsRef<[u8]>) -> anyhow::Result<PgValue> {
+    let bytes = bytes.as_ref();
+    match bytes {
+        [octet0, octet1, octet2, octet3, octet4, octet5, octet6, octet7] => {
+            Ok(PgValue::Macaddr8((
+                *octet0, *octet1, *octet2, *octet3, *octet4, *octet5, *octet6, *octet7,
+            )))
+        }
+        _ => bail!("unexpected number of bytes in received macaddress"),
+    }
+}
+
+/// Convert a 6byte MacAddress to a tuple of bytes
+#[allow(clippy::type_complexity)]
+fn macaddr8_to_bytes(m: MacAddress) -> anyhow::Result<(u8, u8, u8, u8, u8, u8, u8, u8)> {
+    match m.as_bytes() {
+        [octet0, octet1, octet2, octet3, octet4, octet5, octet6, octet7] => Ok((
+            *octet0, *octet1, *octet2, *octet3, *octet4, *octet5, *octet6, *octet7,
+        )),
+        _ => bail!("unexpected number of bytes in received macaddress"),
+    }
+}
+
+impl ConnectionOptions {
+    /// Convert this ConnetionOptions into a representative conenction token
+    pub fn connection_token(&self, source_id: &str) -> ConnectionToken {
+        match self {
+            ConnectionOptions::Managed => managed_connection_token_id(Some(source_id)),
+            ConnectionOptions::NamedProfile(name) => {
+                // todo(feat): Allow configurable deduping/sharing of profiles betwee}n components?
+                named_profile_connection_token_id(name, Some(source_id))
+            }
+            ConnectionOptions::Manual(opts) => {
+                // todo(feat): Allow configurable deduping/sharing of manual connections between components?
+                let mut hasher = DefaultHasher::new();
+                opts.hash(&mut hasher);
+                format!(
+                    "manual-{source_id}-{}",
+                    format!("{:x}", hasher.finish()).trim().to_lowercase()
+                )
+            }
+        }
+    }
+}
+
+impl TryFrom<ConnectionCreateOptions> for deadpool_postgres::Config {
+    type Error = anyhow::Error;
+
+    fn try_from(opts: ConnectionCreateOptions) -> anyhow::Result<Self> {
+        // todo(feat): support multiple hosts & ports
+        // todo(feat): support load balancing
+        let mut cfg = deadpool_postgres::Config::new();
+        cfg.host = Some(opts.host);
+        cfg.user = Some(opts.username);
+        cfg.password = Some(opts.password);
+        cfg.dbname = Some(opts.database);
+        cfg.port = Some(opts.port);
+        Ok(cfg)
+    }
+}
+
+impl TryFrom<&Date> for chrono::NaiveDate {
+    type Error = anyhow::Error;
+
+    fn try_from(d: &Date) -> anyhow::Result<NaiveDate> {
+        match d {
+            Date::PositiveInfinity => Ok(NaiveDate::MAX),
+            Date::NegativeInfinity => Ok(NaiveDate::MAX),
+            Date::Ymd((year, month, day)) => NaiveDate::from_ymd_opt(*year, *month, *day)
+                .with_context(|| format!("failed to build date from ymd ({year}/{month}/{day})")),
+        }
+    }
+}
+
+impl From<NaiveDate> for Date {
+    fn from(nd: NaiveDate) -> Date {
+        match nd {
+            NaiveDate::MAX => Date::PositiveInfinity,
+            NaiveDate::MIN => Date::NegativeInfinity,
+            nd => Date::Ymd((nd.year(), nd.month(), nd.day())),
+        }
+    }
+}
+
+impl TryFrom<&Time> for NaiveTime {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        Time {
+            hour,
+            min,
+            sec,
+            micro,
+        }: &Time,
+    ) -> anyhow::Result<NaiveTime> {
+        NaiveTime::from_hms_micro_opt(*hour, *min, *sec, *micro)
+            .with_context(|| format!("failed to convert time [{hour}h {min}m {sec}s {micro}micro]"))
+    }
+}
+
+impl From<NaiveTime> for Time {
+    fn from(nt: NaiveTime) -> Time {
+        Time {
+            hour: nt.hour(),
+            min: nt.minute(),
+            sec: nt.second(),
+            micro: nt.nanosecond() / 1_000,
+        }
+    }
+}
+
+impl TryFrom<&Timestamp> for NaiveDateTime {
+    type Error = anyhow::Error;
+
+    fn try_from(Timestamp { date, time }: &Timestamp) -> anyhow::Result<NaiveDateTime> {
+        match (date, time) {
+            (Date::NegativeInfinity, _) | (Date::PositiveInfinity, _) => {
+                bail!("negative/positive infinite date times are not supported")
+            }
+            (Date::Ymd(_), time) => Ok(NaiveDateTime::new(date.try_into()?, time.try_into()?)),
+        }
+    }
+}
+
+impl From<NaiveDateTime> for Timestamp {
+    fn from(ndt: NaiveDateTime) -> Timestamp {
+        Timestamp {
+            date: ndt.date().into(),
+            time: ndt.time().into(),
+        }
+    }
+}
+
+impl TryFrom<&Offset> for FixedOffset {
+    type Error = anyhow::Error;
+
+    fn try_from(timezone: &Offset) -> anyhow::Result<FixedOffset> {
+        match timezone {
+            Offset::EasternHemisphereSecs(secs) => FixedOffset::east_opt(*secs)
+                .with_context(|| format!("failed to convert eastern hemisphere seconds [{secs}]")),
+            Offset::WesternHemisphereSecs(secs) => FixedOffset::west_opt(*secs)
+                .with_context(|| format!("failed to convert western hemisphere seconds [{secs}]")),
+        }
+    }
+}
+
+impl TryFrom<&TimestampTz> for DateTime<Utc> {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        TimestampTz { timestamp, offset }: &TimestampTz,
+    ) -> anyhow::Result<chrono::DateTime<Utc>> {
+        let fixed_offset: FixedOffset = offset.try_into()?;
+        let timestamp: NaiveDateTime = timestamp.try_into()?;
+        Ok(
+            chrono::DateTime::<FixedOffset>::from_naive_utc_and_offset(timestamp, fixed_offset)
+                .into(),
+        )
+    }
+}
+
+impl From<DateTime<Utc>> for TimestampTz {
+    fn from(dt: DateTime<Utc>) -> TimestampTz {
+        TimestampTz {
+            offset: Offset::WesternHemisphereSecs(dt.offset().fix().local_minus_utc()),
+            timestamp: dt.naive_local().into(),
+        }
+    }
+}
+
+/// Build a `ResultRow` from a [`Row`]
+pub(crate) fn into_result_row(r: Row) -> ResultRow {
+    let mut rr = Vec::new();
+    for (idx, col) in r.columns().iter().enumerate() {
+        rr.push(ResultRowEntry {
+            column_name: col.name().into(),
+            value: r.get(idx),
+        });
+    }
+    rr
+}
+
+impl ToSql for PgValue {
+    fn to_sql(
+        &self,
+        ty: &PgType,
+        out: &mut BytesMut,
+    ) -> core::result::Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self {
+            // Numeric
+            PgValue::BigInt(n) | PgValue::Int8(n) => n.to_sql(ty, out),
+            PgValue::Int8Array(ns) => ns.to_sql(ty, out),
+            PgValue::BigSerial(n) | PgValue::Serial8(n) => n.to_sql(ty, out),
+            PgValue::Bool(n) | PgValue::Boolean(n) => n.to_sql(ty, out),
+            PgValue::BoolArray(ns) => ns.to_sql(ty, out),
+            PgValue::Double(d)
+            | PgValue::Float8(d) => {
+                f64_from_tuple(d).to_sql(ty, out)
+            }
+            PgValue::Float8Array(ds) => {
+                ds.iter().map(f64_from_tuple).collect::<Vec<_>>().to_sql(ty, out)
+            }
+            PgValue::Real(d)
+            | PgValue::Float4(d) => {
+                f64_from_tuple(d).to_sql(ty, out)
+            }
+            PgValue::Float4Array(ds) => {
+                ds.iter().map(f64_from_tuple).collect::<Vec<_>>().to_sql(ty, out)
+            }
+            PgValue::Integer(n) | PgValue::Int(n) | PgValue::Int4(n) => n.to_sql(ty, out),
+            PgValue::Int4Array(ns) => ns.to_sql(ty, out),
+            PgValue::Numeric(s)
+            | PgValue::Decimal(s)
+            // Money (use is discouraged)
+            //
+            // fractional precision is determined by the database's `lc_monetary` setting.
+            //
+            // NOTE: if you are storing currency amounts, consider
+            // using integer (whole number) counts of smallest indivisible pieces of currency
+            // (ex. cent amounts to represent United States Dollars; 100 cents = 1 USD)
+            | PgValue::Money(s) => {
+                let bigd = pg_bigdecimal::BigDecimal::parse_bytes(s.as_bytes(), 10).ok_or_else(|| {
+                    format!("failed to parse bigint [{s}]")
+                })?;
+                PgNumeric::new(Some(bigd)).to_sql(ty, out)
+            }
+            PgValue::NumericArray(ss) | PgValue::MoneyArray(ss) => {
+                ss.
+                    iter()
+                    .map(|s| {
+                        pg_bigdecimal::BigDecimal::parse_bytes(s.as_bytes(), 10)
+                            .map(|v| PgNumeric::new(Some(v)))
+                            .ok_or_else(|| {
+                                format!("failed to parse bigint [{s}]")
+                            })
+                    })
+                    .collect::<Result<Vec<PgNumeric>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            PgValue::SmallInt(n) | PgValue::Int2(n) => n.to_sql(ty, out),
+            PgValue::Int2Array(ns) => ns.to_sql(ty, out),
+            PgValue::Int2Vector(ns) => ns.to_sql(ty, out),
+            PgValue::Int2VectorArray(ns) => ns.to_sql(ty, out),
+
+            PgValue::Serial(n) | PgValue::Serial4(n) => n.to_sql(ty, out),
+            PgValue::SmallSerial(n) | PgValue::Serial2(n) => n.to_sql(ty, out),
+
+            // Bytes
+            PgValue::Bit((exact_size, bytes)) => {
+                if bytes.len() != *exact_size as usize {
+                    return Err("bitfield size does not match".into());
+                }
+                bytes.to_sql(ty, out)
+            }
+            PgValue::BitArray(many_bits) => {
+                let mut vec: Vec<Vec<u8>> = Vec::new();
+                for (exact_size, bytes) in many_bits.iter() {
+                    if bytes.len() != *exact_size as usize {
+                        return Err("bitfield size does not match".into());
+                    }
+                    vec.push(bytes.to_vec())
+                }
+                vec.to_sql(ty, out)
+            }
+            PgValue::BitVarying((limit, bytes)) | PgValue::Varbit((limit, bytes)) => {
+                if limit.is_some_and(|limit| bytes.len() > limit as usize) {
+                    return Err("bit field length is greater than limit".into());
+                }
+                bytes.to_sql(ty, out)
+            }
+            PgValue::VarbitArray(many_varbits) => {
+                let mut valid_varbits: Vec<Vec<u8>> = Vec::new();
+                for (limit, bytes) in many_varbits {
+                    if limit.is_some_and(|limit| bytes.len() > limit as usize) {
+                        return Err("bit field length is greater than limit".into());
+                    }
+                    valid_varbits.push(bytes.to_vec())
+                }
+                valid_varbits.to_sql(ty, out)
+
+            }
+            PgValue::Bytea(bytes) => bytes.to_sql(ty, out),
+            PgValue::ByteaArray(many_bytes) => many_bytes.to_sql(ty, out),
+
+            // Characters
+            PgValue::Char((len, bytes)) => {
+                if bytes.len() != *len as usize {
+                    return Err("char length does not match specified size".into());
+                }
+                bytes.to_sql(ty, out)
+            }
+            PgValue::CharArray(many_chars) => {
+                let mut valid_chars = Vec::new();
+                for (len, bytes) in many_chars {
+                    if bytes.len() != *len as usize {
+                        return Err("char length does not match specified size".into());
+                    }
+                    valid_chars.push(bytes);
+                }
+                valid_chars.to_sql(ty, out)
+            }
+            PgValue::Varchar((maybe_len, bytes)) => {
+                if let Some(limit) = maybe_len {
+                    if bytes.len() > *limit as usize {
+                        return Err(format!(
+                            "char length [{}] does not match specified limit [{limit}]",
+                            bytes.len(),
+                        )
+                        .into());
+                    }
+                }
+                bytes.to_sql(ty, out)
+            }
+            PgValue::VarcharArray(vs) => {
+                let mut valid_varchars = Vec::new();
+                for (maybe_len, bytes) in vs {
+                    if let Some(limit) = maybe_len {
+                        if bytes.len() > *limit as usize {
+                            return Err(format!(
+                                "char length [{}] does not match specified limit [{limit}]",
+                                bytes.len(),
+                            )
+                                       .into());
+                        }
+                    }
+                    valid_varchars.push(bytes)
+                }
+                valid_varchars.to_sql(ty, out)
+            }
+
+            // Networking
+            PgValue::Cidr(cidr) => {
+                IpCidr::from_str(cidr)
+                    .map_err(|e| format!("invalid cidr: {e}"))?
+                    .to_sql(ty, out)
+            }
+            PgValue::CidrArray(cidrs) => {
+                cidrs
+                    .iter()
+                    .map(|v| IpCidr::from_str(v).map_err(|e| format!("invalid cidr: {e}")))
+                    .collect::<Result<Vec<IpCidr>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            PgValue::Inet(addr) => {
+                IpAddr::from_str(addr)
+                    .map_err(|e| format!("invalid address: {e}"))?
+                    .to_sql(ty, out)
+            }
+            PgValue::InetArray(inets) => {
+                inets
+                    .iter()
+                    .map(|v| IpAddr::from_str(v).map_err(|e| format!("invalid address: {e}")))
+                    .collect::<Result<Vec<IpAddr>, _>>()?
+                    .to_sql(ty, out)
+
+            }
+
+            // EUI-48 (octets)
+            PgValue::Macaddr((octet0, octet1, octet2, octet3, octet4, octet5)) => {
+                MacAddress::from_bytes(&[*octet0, *octet1, *octet2, *octet3, *octet4, *octet5])
+                    .map_err(|e| format!("failed to parse MAC address: {e}"))?
+                    .to_sql(ty, out)
+            }
+            PgValue::MacaddrArray(macs) => {
+                macs
+                    .iter()
+                    .map(|(octet0, octet1, octet2, octet3, octet4, octet5)| MacAddress::from_bytes(&[
+                        *octet0, *octet1, *octet2, *octet3, *octet4, *octet5,
+                    ])
+                         .map_err(|e| format!("failed to parse MAC address: {e}")))
+                    .collect::<Result<Vec<MacAddress>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            // EUI-64 (deprecated)
+            PgValue::Macaddr8((octet0, octet1, octet2, octet3, octet4, octet5, octet6, octet7)) => {
+                MacAddress::from_bytes(&[
+                    *octet0, *octet1, *octet2, *octet3, *octet4, *octet5, *octet6, *octet7,
+                ])
+                    .map_err(|e| format!("failed to parse MAC address: {e}"))?
+                    .to_sql(ty, out)
+            }
+            PgValue::Macaddr8Array(macs) => {
+                macs
+                    .iter()
+                    .map(|(octet0, octet1, octet2, octet3, octet4, octet5, octet6, octet7)| MacAddress::from_bytes(&[
+                        *octet0, *octet1, *octet2, *octet3, *octet4, *octet5, *octet6, *octet7,
+                    ])
+                         .map_err(|e| format!("failed to parse MAC address: {e}")))
+                    .collect::<Result<Vec<MacAddress>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            // Geo
+            PgValue::Circle(_) | PgValue::CircleArray(_) => {
+                Err("circle & circle[] are not supported".into())
+            },
+            PgValue::Box(((start_x, start_y), (end_x, end_y)))  => {
+                let start_x = f64_from_tuple(start_x);
+                let start_y = f64_from_tuple(start_y);
+                let end_x = f64_from_tuple(end_x);
+                let end_y = f64_from_tuple(end_y);
+                Rect::<f64>::new(
+                    coord! { x: start_x, y: start_y },
+                    coord! { x: end_x, y: end_y },
+                ).to_sql(ty, out)
+            }
+
+            PgValue::Line(((start_x, start_y), (end_x, end_y))) | PgValue::Lseg(((start_x, start_y), (end_x, end_y))) => {
+                LineString::<f64>::new(vec![
+                    coord!{ x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                    coord!{ x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+                ]).to_sql(ty, out)
+            },
+            PgValue::LineArray(lines) | PgValue::LsegArray(lines) => {
+                lines
+                    .iter()
+                    .map(|((start_x, start_y), (end_x, end_y))| LineString::<f64>::new(vec![
+                        coord! { x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                        coord! { x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+                    ]))
+                    .collect::<Vec<LineString>>()
+                    .to_sql(ty, out)
+            }
+
+            PgValue::BoxArray(boxes) => {
+                boxes
+                    .iter()
+                    .map(|((start_x, start_y), (end_x, end_y))| Rect::<f64>::new(
+                        coord! { x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                        coord! { x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+                    ))
+                    .collect::<Vec<Rect<f64>>>()
+                    .to_sql(ty, out)
+
+            }
+
+            PgValue::Point((x, y)) => {
+                Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)).to_sql(ty, out)
+            },
+            PgValue::PointArray(points) => {
+                points.iter().map(|(x, y)| Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y))).collect::<Vec<Point>>().to_sql(ty, out)
+            }
+
+            PgValue::Path(points) | PgValue::Polygon(points) => {
+                if points.is_empty() { return Err("invalid polygon, no points specified".into()) }
+                points
+                    .iter()
+                    .map(|(x, y)|  Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)))
+                    .collect::<Vec<Point<f64>>>()
+                    .to_sql(ty, out)
+            },
+
+            PgValue::PathArray(paths) | PgValue::PolygonArray(paths) => {
+                paths
+                    .iter()
+                    .map(|path| {
+                        path
+                            .iter()
+                            .map(|(x, y)|  Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)))
+                            .collect::<Vec<Point<f64>>>()
+                    })
+                    .collect::<Vec<Vec<Point<f64>>>>()
+                    .to_sql(ty, out)
+            }
+
+
+            // Date-time
+            PgValue::Date(d) => {
+                let d: NaiveDate = d.try_into()?;
+                d.to_sql(ty, out)
+            }
+            PgValue::DateArray(ds) => {
+                ds
+                    .iter()
+                    .map(|v| v.try_into())
+                    .collect::<Result<Vec<NaiveDate>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            PgValue::Interval(_) | PgValue::IntervalArray(_) => {
+                Err("interval not supported (consider using a cast like 'value'::text::interval)".into())
+            },
+
+            PgValue::Time(t) => {
+                let t: chrono::NaiveTime = t.try_into()?;
+                t.to_sql(ty, out)
+            }
+            PgValue::TimeArray(ts) => {
+                ts
+                    .iter()
+                    .map(|t| t.try_into())
+                    .collect::<Result<Vec<NaiveTime>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            PgValue::TimeTz(_) | PgValue::TimeTzArray(_) => {
+                Err("timetz not supported (consider using a cast like 'value'::text::timetz)".into())
+            }
+
+            PgValue::Timestamp(ts) => {
+                let ts: NaiveDateTime = ts.try_into()?;
+                ts.to_sql(ty, out)
+            }
+            PgValue::TimestampArray(tss) => {
+                tss
+                    .iter()
+                    .map(|ts| ts.try_into())
+                    .collect::<Result<Vec<NaiveDateTime>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            PgValue::TimestampTz(tstz) => {
+                let tstz: chrono::DateTime<Utc> = tstz.try_into()?;
+                tstz.to_sql(ty, out)
+            }
+            PgValue::TimestampTzArray(tstzs) => {
+                tstzs
+                    .iter()
+                    .map(|tstz| tstz.try_into())
+                    .collect::<Result<Vec<chrono::DateTime<Utc>>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            // JSON
+            PgValue::Json(s) | PgValue::Jsonb(s) => {
+                serde_json::Value::from_str(s)
+                    .map_err(|e| format!("failed to parse JSON: {e}"))?
+                    .to_sql(ty, out)
+            },
+            PgValue::JsonArray(json_strings) | PgValue::JsonbArray(json_strings) => {
+                json_strings
+                    .iter()
+                    .map(|s| serde_json::Value::from_str(s))
+                    .collect::<Result<Vec<serde_json::Value>, _>>()?
+                    .to_sql(ty, out)
+            },
+            // Postgres-internal
+            PgValue::PgLsn(offset) => PgLsn::from(*offset).to_sql(ty, out),
+            PgValue::PgLsnArray(offsets) => {
+                offsets
+                    .iter()
+                    .cloned()
+                    .map(PgLsn::from)
+                    .collect::<Vec<PgLsn>>()
+                    .to_sql(ty, out)
+            }
+            PgValue::PgSnapshot((xmin, xmax, xip_list)) => {
+                format!(
+                    "{xmin}:{xmax}:{}",
+                    xip_list
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                ).to_sql(ty, out)
+            },
+            PgValue::TxidSnapshot(n) => n.to_sql(ty, out),
+
+            // Text
+            PgValue::Name(s) => s.to_sql(ty, out),
+            PgValue::NameArray(ss) => ss.to_sql(ty, out),
+            PgValue::Text(s) => s.to_sql(ty, out),
+            PgValue::TextArray(ss) => ss.to_sql(ty, out),
+            PgValue::Xml(s) => s.to_sql(ty, out),
+            PgValue::XmlArray(ss) => ss.to_sql(ty, out),
+
+            // Full Text Search
+            PgValue::TsQuery(s) => s.to_sql(ty, out),
+            PgValue::TsVector(_) => {
+                Err("tsvector not supported (consider using a cast like 'value'::text::tsvector)".into())
+            }
+
+            // UUIDs
+            PgValue::Uuid(s) => {
+                Uuid::from_str(s)?.to_sql(ty, out)
+            }
+            PgValue::UuidArray(ss) => {
+                ss
+                    .iter()
+                    .map(|v| Uuid::from_str(v.as_ref()))
+                    .collect::<Result<Vec<Uuid>, _>>()?
+                    .to_sql(ty, out)
+            }
+
+            // UUIDs
+            PgValue::Hstore(h) => {
+                let map  = HashMap::<String, Option<String>>::from_iter(h.iter().cloned());
+                map.to_sql(ty, out)
+            }
+        }
+    }
+
+    fn accepts(_ty: &PgType) -> bool {
+        // NOTE: we don't actually support all types, but pretend to, in order to
+        // use more specific/tailored error messages
+        true
+    }
+
+    tokio_postgres::types::to_sql_checked!();
+}
+
+impl FromSql<'_> for PgValue {
+    fn from_sql(ty: &PgType, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        match ty {
+            &tokio_postgres::types::Type::BOOL => Ok(PgValue::Bool(bool::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::BOOL_ARRAY => {
+                Ok(PgValue::BoolArray(Vec::<bool>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::BYTEA => {
+                Ok(PgValue::Bytea(Vec::<u8>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::BYTEA_ARRAY => {
+                Ok(PgValue::ByteaArray(Vec::<Vec<u8>>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::CHAR => {
+                let s = Vec::<u8>::from_sql(ty, raw)?;
+                let len = s.len().try_into()?;
+                Ok(PgValue::Char((len, s)))
+            }
+            &tokio_postgres::types::Type::CHAR_ARRAY => {
+                let list = Vec::<Vec<u8>>::from_sql(ty, raw)?;
+                let mut cs = Vec::new();
+                for c in list {
+                    cs.push((c.len().try_into()?, c));
+                }
+                Ok(PgValue::CharArray(cs))
+            }
+            &tokio_postgres::types::Type::BIT => {
+                let vec = BitVec::from_sql(ty, raw)?;
+                let len = vec.len().try_into()?;
+                Ok(PgValue::Bit((len, vec.to_bytes())))
+            }
+            &tokio_postgres::types::Type::BIT_ARRAY => {
+                let vecs = Vec::<BitVec>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.len().try_into().map(|len| (len, v.to_bytes())))
+                    .collect::<Result<Vec<(u32, Vec<u8>)>, _>>()?;
+                Ok(PgValue::BitArray(vecs))
+            }
+            &tokio_postgres::types::Type::VARBIT => {
+                let vec = BitVec::from_sql(ty, raw)?;
+                let len = vec.len().try_into()?;
+                Ok(PgValue::Bit((len, vec.to_bytes())))
+            }
+            &tokio_postgres::types::Type::VARBIT_ARRAY => {
+                let varbits = Vec::<BitVec>::from_sql(ty, raw)?
+                    .into_iter()
+                    // NOTE: we don't know what the  limit of this varbit was if we only
+                    // have the bytes, default to allowing it to be unbounded
+                    .map(|v| (None, v.to_bytes()))
+                    .collect::<Vec<(Option<u32>, Vec<u8>)>>();
+                Ok(PgValue::VarbitArray(varbits))
+            }
+            &tokio_postgres::types::Type::FLOAT4 => {
+                Ok(PgValue::Float4(f32::from_sql(ty, raw)?.integer_decode()))
+            }
+            &tokio_postgres::types::Type::FLOAT4_ARRAY => Ok(PgValue::Float4Array(
+                Vec::<f32>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|f| f.integer_decode())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::FLOAT8 => {
+                Ok(PgValue::Float8(f64::from_sql(ty, raw)?.integer_decode()))
+            }
+            &tokio_postgres::types::Type::FLOAT8_ARRAY => Ok(PgValue::Float8Array(
+                Vec::<f64>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|f| f.integer_decode())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::INT2 => Ok(PgValue::Int2(i16::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT2_ARRAY => {
+                Ok(PgValue::Int2Array(Vec::<i16>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT2_VECTOR => {
+                Ok(PgValue::Int2Vector(Vec::<i16>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT2_VECTOR_ARRAY => Ok(PgValue::Int2VectorArray(
+                Vec::<Vec<i16>>::from_sql(ty, raw)?,
+            )),
+            &tokio_postgres::types::Type::INT4 => Ok(PgValue::Int4(i32::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT4_RANGE
+            | &tokio_postgres::types::Type::INT4_RANGE_ARRAY
+            | &tokio_postgres::types::Type::INT4MULTI_RANGE
+            | &tokio_postgres::types::Type::INT4MULTI_RANGE_ARRAY => {
+                Err("int4 ranges are not yet supported".into())
+            }
+            &tokio_postgres::types::Type::INT4_ARRAY => Ok(PgValue::Int4Array(
+                Vec::<i32>::from_sql(ty, raw)?.into_iter().collect(),
+            )),
+            &tokio_postgres::types::Type::INT8 => Ok(PgValue::Int8(i64::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT8_ARRAY => {
+                Ok(PgValue::Int8Array(Vec::<i64>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT8MULTI_RANGE
+            | &tokio_postgres::types::Type::INT8MULTI_RANGE_ARRAY
+            | &tokio_postgres::types::Type::INT8_RANGE
+            | &tokio_postgres::types::Type::INT8_RANGE_ARRAY => {
+                Err("int8 ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::MONEY => Ok(PgValue::Money(Numeric::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::MONEY_ARRAY => {
+                Ok(PgValue::MoneyArray(Vec::<Numeric>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMERIC => {
+                Ok(PgValue::Numeric(Numeric::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMERIC_ARRAY => {
+                Ok(PgValue::NumericArray(Vec::<Numeric>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMMULTI_RANGE
+            | &tokio_postgres::types::Type::NUMMULTI_RANGE_ARRAY
+            | &tokio_postgres::types::Type::NUM_RANGE
+            | &tokio_postgres::types::Type::NUM_RANGE_ARRAY => {
+                Err("numeric ranges are not yet supported".into())
+            }
+
+            // JSON
+            &tokio_postgres::types::Type::JSON => Ok(PgValue::Json(
+                serde_json::Value::from_sql(ty, raw)?.to_string(),
+            )),
+            &tokio_postgres::types::Type::JSON_ARRAY => Ok(PgValue::JsonArray(
+                Vec::<serde_json::Value>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::JSONB => Ok(PgValue::Json(
+                serde_json::Value::from_sql(ty, raw)?.to_string(),
+            )),
+            &tokio_postgres::types::Type::JSONB_ARRAY => Ok(PgValue::JsonbArray(
+                Vec::<serde_json::Value>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::VARCHAR => {
+                Ok(PgValue::Varchar(
+                    // We cannot know whether the varchar had a limit
+                    Vec::<u8>::from_sql(ty, raw).map(|v| (None, v))?,
+                ))
+            }
+            &tokio_postgres::types::Type::VARCHAR_ARRAY => Ok(PgValue::VarcharArray(
+                Vec::<Vec<u8>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|s| (None, s))
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::NAME => Ok(PgValue::Name(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::NAME_ARRAY => {
+                Ok(PgValue::NameArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::TEXT => Ok(PgValue::Text(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::TEXT_ARRAY => {
+                Ok(PgValue::TextArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::XML => Ok(PgValue::Xml(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::XML_ARRAY => {
+                Ok(PgValue::XmlArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::BOX => {
+                Ok(PgValue::Box(rect_to_hashable_f64s(Rect::<f64>::from_sql(
+                    ty, raw,
+                )?)))
+            }
+            &tokio_postgres::types::Type::BOX_ARRAY => Ok(PgValue::BoxArray(
+                Vec::<Rect<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(rect_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::CIRCLE | &tokio_postgres::types::Type::CIRCLE_ARRAY => {
+                Err("circle & circle[] are not supported".into())
+            }
+            &tokio_postgres::types::Type::LINE => Ok(PgValue::Line(
+                linestring_to_hashable_f64s_tuple(LineString::<f64>::from_sql(ty, raw)?)?,
+            )),
+            &tokio_postgres::types::Type::LINE_ARRAY => Ok(PgValue::LineArray(
+                Vec::<LineString<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(linestring_to_hashable_f64s_tuple)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            &tokio_postgres::types::Type::LSEG => Ok(PgValue::Lseg(
+                linestring_to_hashable_f64s_tuple(LineString::<f64>::from_sql(ty, raw)?)?,
+            )),
+            &tokio_postgres::types::Type::LSEG_ARRAY => Ok(PgValue::LsegArray(
+                Vec::<LineString<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(linestring_to_hashable_f64s_tuple)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            &tokio_postgres::types::Type::PATH => Ok(PgValue::Path(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::PATH_ARRAY => Ok(PgValue::PathArray(
+                Vec::<Vec<Point<f64>>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|points| points.into_iter().map(point_to_hashable_f64s).collect())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POINT => {
+                let point = Point::<f64>::from_sql(ty, raw)?;
+                Ok(PgValue::Point(point_to_hashable_f64s(point)))
+            }
+            &tokio_postgres::types::Type::POINT_ARRAY => Ok(PgValue::PointArray(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POLYGON => Ok(PgValue::Polygon(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POLYGON_ARRAY => Ok(PgValue::PolygonArray(
+                Vec::<Vec<Point<f64>>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.into_iter().map(point_to_hashable_f64s).collect())
+                    .collect::<Vec<Vec<_>>>(),
+            )),
+
+            &tokio_postgres::types::Type::CIDR => {
+                let cidr = IpCidr::from_sql(ty, raw)?;
+                Ok(PgValue::Cidr(cidr.to_string()))
+            }
+            &tokio_postgres::types::Type::CIDR_ARRAY => Ok(PgValue::CidrArray(
+                Vec::<IpCidr>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+            &tokio_postgres::types::Type::INET => {
+                let inet = IpAddr::from_sql(ty, raw)?;
+                Ok(PgValue::Inet(inet.to_string()))
+            }
+            &tokio_postgres::types::Type::INET_ARRAY => Ok(PgValue::InetArray(
+                Vec::<IpAddr>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+
+            &tokio_postgres::types::Type::MACADDR => {
+                Ok(bytes_to_macaddr(MacAddress::from_sql(ty, raw)?.as_bytes())?)
+            }
+            &tokio_postgres::types::Type::MACADDR_ARRAY => Ok(PgValue::MacaddrArray(
+                Vec::<MacAddress>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(macaddr_to_bytes)
+                    .collect::<Result<Vec<_>, _>>()?
+            )),
+            &tokio_postgres::types::Type::MACADDR8 => {
+                Ok(bytes_to_macaddr8(MacAddress::from_sql(ty, raw)?.as_bytes())?)
+            }
+            &tokio_postgres::types::Type::MACADDR8_ARRAY => Ok(PgValue::Macaddr8Array(
+                Vec::<MacAddress>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(macaddr8_to_bytes)
+                    .collect::<Result<Vec<_>, _>>()?
+            )),
+            &tokio_postgres::types::Type::DATE => {
+                Ok(PgValue::Date(NaiveDate::from_sql(ty, raw)?.into()))
+            }
+            &tokio_postgres::types::Type::DATE_ARRAY => {
+                Ok(PgValue::DateArray(Vec::<NaiveDate>::from_sql(ty, raw)?
+                   .into_iter()
+                   .map(|t| t.into())
+                   .collect::<Vec<Date>>()))
+            }
+
+            &tokio_postgres::types::Type::DATE_RANGE
+            | &tokio_postgres::types::Type::DATE_RANGE_ARRAY
+            | &tokio_postgres::types::Type::DATEMULTI_RANGE => {
+                Err("date ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIME => {
+                Ok(PgValue::Time(NaiveTime::from_sql(ty, raw)?.into()))
+            }
+            &tokio_postgres::types::Type::TIME_ARRAY => {
+                Ok(PgValue::TimeArray(Vec::<NaiveTime>::from_sql(ty, raw)?
+                   .into_iter()
+                   .map(|t| t.into())
+                   .collect::<Vec<Time>>()))
+            }
+            &tokio_postgres::types::Type::TIMESTAMP => {
+                Ok(PgValue::Timestamp(NaiveDateTime::from_sql(ty, raw)?.into()))
+
+            },
+             &tokio_postgres::types::Type::TIMESTAMP_ARRAY => {
+                Ok(PgValue::TimestampArray(Vec::<NaiveDateTime>::from_sql(ty, raw)?
+                   .into_iter()
+                   .map(|t| t.into())
+                   .collect::<Vec<Timestamp>>()))
+             }
+
+            &tokio_postgres::types::Type::INTERVAL
+            | &tokio_postgres::types::Type::INTERVAL_ARRAY => {
+                Err("intervals are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIMETZ |
+            &tokio_postgres::types::Type::TIMETZ_ARRAY => {
+                Err("timetz is not supported".into())
+            }
+
+            &tokio_postgres::types::Type::TS_RANGE
+            | &tokio_postgres::types::Type::TS_RANGE_ARRAY
+            | &tokio_postgres::types::Type::TSMULTI_RANGE
+            | &tokio_postgres::types::Type::TSMULTI_RANGE_ARRAY => {
+                Err("timestamp ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIMESTAMPTZ => {
+                Ok(PgValue::TimestampTz(DateTime::<Utc>::from_sql(ty, raw)?.into()))
+            }
+            &tokio_postgres::types::Type::TIMESTAMPTZ_ARRAY => Ok(PgValue::TimestampTzArray(
+                Vec::<DateTime<Utc>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.into())
+                    .collect::<Vec<TimestampTz>>()
+            )),
+
+            &tokio_postgres::types::Type::TSTZ_RANGE
+            | &tokio_postgres::types::Type::TSTZ_RANGE_ARRAY
+            | &tokio_postgres::types::Type::TSTZMULTI_RANGE => {
+                Err("timestamptz ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::UUID => {
+                Ok(PgValue::Uuid(Uuid::from_sql(ty, raw)?.to_string()))
+            }
+            &tokio_postgres::types::Type::UUID_ARRAY => Ok(PgValue::UuidArray(
+                Vec::<Uuid>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+            &tokio_postgres::types::Type::PG_LSN => {
+                Ok(PgValue::PgLsn(PgLsn::from_sql(ty, raw)?.into()))
+            }
+            &tokio_postgres::types::Type::PG_LSN_ARRAY => Ok(PgValue::PgLsnArray(
+                Vec::<PgLsn>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.into())
+                    .collect::<Vec<u64>>(),
+            )),
+
+            // All other types are unsupported
+            t => Err(format!("unsupported type [{}], consider using a cast like 'value'::string or 'value'::jsonb", t).into()),
+        }
+    }
+
+    fn accepts(_ty: &PgType) -> bool {
+        // NOTE: we don't actually support all types, but pretend to, in order to
+        // use a more specific error message that encourages using a cast where possible
+        true
+    }
+}

--- a/crates/provider-sqldb-postgres/src/config.rs
+++ b/crates/provider-sqldb-postgres/src/config.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use tracing::{debug, warn};
+
+use crate::bindings::ConnectionCreateOptions;
+
+const POSTGRES_DEFAULT_PORT: u16 = 5432;
+
+fn parse_prefixed_config_from_map(
+    prefix: &str,
+    config: &HashMap<String, String>,
+) -> Option<ConnectionCreateOptions> {
+    let keys = [
+        format!("{prefix}HOST"),
+        format!("{prefix}PORT"),
+        format!("{prefix}USERNAME"),
+        format!("{prefix}PASSWORD"),
+        format!("{prefix}DATABASE"),
+        format!("{prefix}TLS_REQUIRED"),
+    ];
+    // todo(refactor): once host can standardize keys, use it (likely lowercase)
+    match keys
+        .iter()
+        .map(|k| config.get(k))
+        .collect::<Vec<Option<&String>>>()[..]
+    {
+        [Some(host), Some(port), Some(username), Some(password), Some(database), Some(tls_required)] => {
+            Some(ConnectionCreateOptions {
+                host: host.to_string(),
+                port: port.parse::<u16>().unwrap_or_else(|_e| {
+                    warn!("invalid port value [{port}], using {POSTGRES_DEFAULT_PORT}");
+                    POSTGRES_DEFAULT_PORT
+                }),
+                username: username.to_string(),
+                password: password.to_string(),
+                tls_required: matches!(tls_required.to_lowercase().as_str(), "true" | "yes"),
+                database: database.to_string(),
+            })
+        }
+        _ => {
+            warn!("failed to find keys in configuration: [{:?}]", keys);
+            None
+        }
+    }
+}
+
+/// Attempt to parse the only managed from a given config map
+pub(crate) fn parse_managed_config(
+    config: &HashMap<String, String>,
+) -> Option<ConnectionCreateOptions> {
+    debug!("parsing managed config");
+    parse_prefixed_config_from_map("MANAGED_", config)
+}
+
+/// Attempt to parse profile configurations from a config map,
+/// Returning the profiles names along with the create options
+pub(crate) fn parse_profile_configs(
+    config: &HashMap<String, String>,
+) -> Vec<(String, ConnectionCreateOptions)> {
+    config
+        .keys()
+        .filter_map(|s| match s.split('_').collect::<Vec<_>>()[..] {
+            ["PROFILE", name, ..] => {
+                debug!("parsing named profile config [{name}]");
+                parse_prefixed_config_from_map(format!("PROFILE_{name}_").as_str(), config)
+                    .map(|cfg| (name.to_string(), cfg))
+            }
+            _ => None,
+        })
+        .collect::<Vec<(String, ConnectionCreateOptions)>>()
+}

--- a/crates/provider-sqldb-postgres/src/lib.rs
+++ b/crates/provider-sqldb-postgres/src/lib.rs
@@ -1,0 +1,514 @@
+//! SQL-powered database access provider implementing `wasmcloud:postgres` for connecting
+//! to Postgres clusters.
+//!
+//! This implementation is multi-threaded and operations between different actors
+//! use different connections and can run in parallel.
+//!
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use deadpool_postgres::Pool;
+use futures::stream::TryStreamExt;
+use tokio::sync::RwLock;
+use tokio_postgres::Statement;
+use tracing::{debug, error, instrument};
+use ulid::Ulid;
+
+use wasmcloud_provider_sdk::{
+    get_connection, run_provider, LinkConfig, Provider, ProviderInitConfig,
+};
+
+mod bindings;
+use bindings::{
+    into_result_row, serve, ConnectionCreateOptions, ConnectionOptions, ConnectionToken,
+    CreateConnectionError, PgValue, PreparedStatementExecError, PreparedStatementToken, QueryError,
+    ResultRow, StatementPrepareError,
+};
+
+mod config;
+use config::{parse_managed_config, parse_profile_configs};
+
+use wasmcloud_provider_sdk::Context;
+
+#[derive(Clone, Default)]
+struct PostgresProvider {
+    create_options: Arc<RwLock<HashMap<ConnectionToken, ConnectionCreateOptions>>>,
+    connections: Arc<RwLock<HashMap<ConnectionToken, Pool>>>,
+    prepared_statements: Arc<RwLock<HashMap<PreparedStatementToken, (Statement, ConnectionToken)>>>,
+}
+
+/// Run [`PostgresProvider`] as a wasmCloud provider
+pub async fn run() -> anyhow::Result<()> {
+    let provider = PostgresProvider::default();
+    let shutdown = run_provider(provider.clone(), "sqldb-postgres-provider")
+        .await
+        .context("failed to run provider")?;
+    let connection = get_connection();
+    serve(
+        &connection.get_wrpc_client(connection.provider_key()),
+        provider,
+        shutdown,
+    )
+    .await
+}
+
+impl PostgresProvider {
+    /// Create and store a connection pool, if not already present
+    async fn ensure_pool(
+        &self,
+        token: impl AsRef<str>,
+        create_opts: ConnectionCreateOptions,
+    ) -> Result<ConnectionToken> {
+        let token = token.as_ref();
+        // Exit early if a connection with the given token is already present
+        {
+            let connections = self.connections.read().await;
+            if connections.get(token).is_some() {
+                return Ok(token.into());
+            }
+        }
+
+        // Build the new connection pool
+        let runtime = Some(deadpool_postgres::Runtime::Tokio1);
+        let tls_required = create_opts.tls_required;
+        let cfg: deadpool_postgres::Config = create_opts.try_into()?;
+        let pool = if tls_required {
+            create_tls_pool(cfg, runtime)
+        } else {
+            cfg.create_pool(runtime, tokio_postgres::NoTls)
+                .context("failed to create non-TLS postgres pool")
+        }?;
+
+        // Save the newly created connection to the pool
+        let mut connections = self.connections.write().await;
+        connections.insert(token.into(), pool);
+        Ok(token.into())
+    }
+
+    /// Perform a query
+    async fn do_query(
+        &self,
+        connection_token: &str,
+        query: &str,
+        params: Vec<PgValue>,
+    ) -> Result<Vec<ResultRow>, QueryError> {
+        let connections = self.connections.read().await;
+        let pool = connections.get(connection_token).ok_or_else(|| {
+            QueryError::Unexpected(format!(
+                "missing connection pool for token [{connection_token}] while querying"
+            ))
+        })?;
+
+        let client = pool.get().await.map_err(|e| {
+            QueryError::Unexpected(format!("failed to build client from pool: {e}"))
+        })?;
+
+        let rows = client
+            .query_raw(query, params)
+            .await
+            .map_err(|e| QueryError::Unexpected(format!("failed to perform query: {e}")))?;
+
+        // todo(fix): once async stream support is available & in contract
+        // replace this with a mapped stream
+        rows.map_ok(into_result_row)
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| QueryError::Unexpected(format!("failed to evaluate full row: {e}")))
+    }
+
+    /// Prepare a statement
+    async fn do_statement_prepare(
+        &self,
+        connection_token: &str,
+        query: &str,
+    ) -> Result<PreparedStatementToken, StatementPrepareError> {
+        let connections = self.connections.read().await;
+        let pool = connections.get(connection_token).ok_or_else(|| {
+            StatementPrepareError::Unexpected(format!(
+                "failed to find connection pool for token [{connection_token}]"
+            ))
+        })?;
+
+        let client = pool.get().await.map_err(|e| {
+            StatementPrepareError::Unexpected(format!("failed to build client from pool: {e}"))
+        })?;
+
+        let statement = client.prepare(query).await.map_err(|e| {
+            StatementPrepareError::Unexpected(format!("failed to prepare query: {e}"))
+        })?;
+
+        let statement_token = format!("prepared-statement-{}", Ulid::new().to_string());
+
+        let mut prepared_statements = self.prepared_statements.write().await;
+        prepared_statements.insert(
+            statement_token.clone(),
+            (statement, connection_token.into()),
+        );
+
+        Ok(statement_token)
+    }
+
+    /// Execute a prepared statement, returning the number of rows affected
+    async fn do_statement_execute(
+        &self,
+        statement_token: &str,
+        params: Vec<PgValue>,
+    ) -> Result<u64, PreparedStatementExecError> {
+        let statements = self.prepared_statements.read().await;
+        let (statement, connection_token) = statements.get(statement_token).ok_or_else(|| {
+            PreparedStatementExecError::Unexpected(format!(
+                "missing prepared statement with statement ID [{statement_token}]"
+            ))
+        })?;
+
+        let connections = self.connections.read().await;
+        let pool = connections.get(connection_token).ok_or_else(|| {
+            PreparedStatementExecError::Unexpected(format!(
+                "missing connection pool for token [{connection_token}], statement ID [{statement_token}]"
+            ))
+        })?;
+        let client = pool.get().await.map_err(|e| {
+            PreparedStatementExecError::Unexpected(format!("failed to build client from pool: {e}"))
+        })?;
+
+        let rows_affected = client.execute_raw(statement, params).await.map_err(|e| {
+            PreparedStatementExecError::Unexpected(format!(
+                "failed to execute prepared statement with token [{statement_token}]: {e}"
+            ))
+        })?;
+
+        Ok(rows_affected)
+    }
+
+    /// Ingest all connection configs (managed/profile) that are specified in a given config map
+    ///
+    /// This method will populate `self.create_options` with configuration for connections that
+    /// will be made (usually as late as possible, at query time)
+    async fn ingest_connection_configs_from_map(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<()> {
+        let managed_config = parse_managed_config(config);
+        let profile_configs = parse_profile_configs(config);
+
+        // We can return early if there were no configs to parse
+        if managed_config.is_none() && profile_configs.is_empty() {
+            return Ok(());
+        }
+
+        let mut create_options = self.create_options.write().await;
+        if let Some(config) = managed_config {
+            debug!("ingested managed config");
+            create_options.insert(managed_connection_token_id(None), config);
+        }
+        for (profile_name, config) in profile_configs {
+            debug!("ingested named profile config [{profile_name}]");
+            create_options.insert(
+                named_profile_connection_token_id(&profile_name, None),
+                config,
+            );
+        }
+        Ok(())
+    }
+
+    /// Create a managed connection config for a given source (usually a linked component)
+    ///
+    /// Usually this means making a copy of the existing managed connection, specialized for
+    /// particular source.
+    async fn create_managed_connection_config_for_source(&self, source_id: &str) -> Result<()> {
+        let managed_token = managed_connection_token_id(None);
+        // Get the options for the default managed connection
+        let create_options = self
+            .create_options
+            .read()
+            .await
+            .get(&managed_token)
+            .cloned()
+            .with_context(|| {
+                format!("failed to find connection options for token [{managed_token}]")
+            })?;
+
+        // Create a pool if one isn't already present for this particular source,
+        // based on the managed one
+        self.ensure_pool(managed_connection_token_id(Some(source_id)), create_options)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Create a named connection config for a given source (usually a linked component)
+    ///
+    /// Normally this means making a copy of existing named profile connection configuration
+    /// for a given source.
+    async fn create_named_profile_connection_config_for_source(
+        &self,
+        profile_name: &str,
+        source_id: &str,
+    ) -> Result<()> {
+        let existing = {
+            let connections = self.connections.read().await;
+            connections
+                .get(&named_profile_connection_token_id(profile_name, None))
+                .with_context(|| format!("no existing named profile [{profile_name}] connection (was initial config specified?)"))?
+                .clone()
+        };
+
+        // todo(feat): enable overriding configuration
+        let mut connections = self.connections.write().await;
+        connections.insert(
+            named_profile_connection_token_id(profile_name, Some(source_id)),
+            existing,
+        );
+        Ok(())
+    }
+}
+
+impl Provider for PostgresProvider {
+    /// Initialize the provider
+    ///
+    /// This method is only run *once* at provider startup, and has access to configuration
+    /// that was provided to the provider, prior to any links being established.
+    ///
+    /// Since this provider is expected to receive configuration for managed and named profile
+    /// connections *before* connections are made, gathering of those configurations should be done here.
+    #[instrument(level = "debug", skip_all)]
+    async fn init(&self, init_config: impl ProviderInitConfig) -> anyhow::Result<()> {
+        let cfg = init_config.get_config();
+        self.ingest_connection_configs_from_map(cfg)
+            .await
+            .context("failed to ingest configurations from startup config")?;
+        Ok(())
+    }
+
+    /// Handle being linked to a source (likely a component) as a target
+    ///
+    /// Managed and named profile connections are built at provider initialization, but if per-component
+    /// connections are enabled (the default), then each component will get it's own pool, *based* on the
+    /// managed profile selected.
+    ///
+    /// Completely unmanaged connections (where the component must specify all the connection options)
+    /// are handled as connections are made/destroyed by clients.
+    #[instrument(level = "debug", skip_all, fields(source_id))]
+    async fn receive_link_config_as_target(
+        &self,
+        LinkConfig {
+            source_id, config, ..
+        }: LinkConfig<'_>,
+    ) -> anyhow::Result<()> {
+        // If the component specified a named profile, use it
+        if let Some(profile_name) = config.get("CONNECTION_PROFILE") {
+            if let Err(error) = self
+                .create_named_profile_connection_config_for_source(profile_name, source_id)
+                .await
+            {
+                error!(
+                    ?error,
+                    source_id, profile_name, "failed to create named connection config"
+                );
+            }
+        }
+
+        // Create an instance of the managed connection
+        //
+        // todo(feat): we might be able to check for the interface here (`managed-query`?)
+        if let Err(error) = self
+            .create_managed_connection_config_for_source(source_id)
+            .await
+        {
+            error!(
+                ?error,
+                source_id, "failed to create managed connection config",
+            );
+        };
+        Ok(())
+    }
+
+    /// Handle notification that a link is dropped
+    ///
+    /// Generally we can release the resources (connections) associated with the source
+    #[instrument(level = "debug", skip(self))]
+    async fn delete_link(&self, source_id: &str) -> anyhow::Result<()> {
+        let token = managed_connection_token_id(Some(source_id));
+        let mut prepared_statements = self.prepared_statements.write().await;
+        prepared_statements
+            .retain(|_stmt_token, (_conn, connection_token)| *connection_token != token);
+        drop(prepared_statements);
+        let mut connections = self.connections.write().await;
+        connections.remove(&token);
+        drop(connections);
+        Ok(())
+    }
+
+    /// Handle shutdown request by closing all connections
+    #[instrument(level = "debug", skip(self))]
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        let mut prepared_statements = self.prepared_statements.write().await;
+        prepared_statements.drain();
+        let mut connections = self.connections.write().await;
+        connections.drain();
+        Ok(())
+    }
+}
+
+/// Implement the `wasmcloud:postgres/connection` interface for [`PostgresProvider`]
+impl bindings::connection::Handler<Option<Context>> for PostgresProvider {
+    #[instrument(level = "debug", skip_all, fields(connection_token, query))]
+    async fn create_connection(
+        &self,
+        ctx: Option<Context>,
+        opts: ConnectionOptions,
+    ) -> Result<Result<ConnectionToken, CreateConnectionError>> {
+        // Get the source ID of the incoming connection
+        let source_id = ctx.and_then(|c| c.component).ok_or_else(|| {
+            CreateConnectionError::Unexpected("failed to get source ID from context".into())
+        })?;
+
+        // Generate the connection token for the connection we'll create
+        let token = opts.connection_token(&source_id);
+
+        // Return early if a pool already exists
+        {
+            let connections = self.connections.read().await;
+            if connections.get(&token).is_some() {
+                return Ok(Ok(token));
+            }
+        }
+
+        let lookup = self.create_options.read().await;
+        let create_connection_opts = match opts {
+            // Managed connections should *already* have config specified, via MANAGED_* named config values
+            ConnectionOptions::Managed => {
+                lookup
+                    .get(&token)
+                    .ok_or_else(|| CreateConnectionError::Unexpected("missing managed connection details, were MANAGED_* named config values specified?".into()))?
+            }
+            // Managed connections should *already* have config specified, via PROFILE_<name>_* named config values
+            ConnectionOptions::NamedProfile(name) => {
+                lookup
+                    .get(&token)
+                    .ok_or_else(|| CreateConnectionError::Unexpected(format!("missing profile connection details, were PROFILE_{name}_* named config values specified?")))?
+            }
+            // Manual connections must be made on the spot (if they haven't already been),
+            // so we can just pass through what we've been given
+            ConnectionOptions::Manual(ref opts) => opts,
+        };
+
+        // Ensure the pool exists
+        let token = self
+            .ensure_pool(token, create_connection_opts.clone())
+            .await
+            .map_err(|e| {
+                CreateConnectionError::Unexpected(format!("failed to create pool: {e}"))
+            })?;
+
+        Ok(Ok(token))
+    }
+}
+
+/// Implement the `wasmcloud:postgres/managed-query` interface for [`PostgresProvider`]
+impl bindings::managed_query::Handler<Option<Context>> for PostgresProvider {
+    #[instrument(level = "debug", skip_all, fields(connection_token, query))]
+    async fn query(
+        &self,
+        ctx: Option<Context>,
+        query: String,
+        params: Vec<PgValue>,
+    ) -> Result<Result<Vec<ResultRow>, QueryError>> {
+        let source_id = ctx
+            .and_then(|c| c.component)
+            .ok_or_else(|| QueryError::Unexpected("failed to get source ID from context".into()))?;
+        let token = managed_connection_token_id(Some(&source_id));
+        Ok(self.do_query(&token, &query, params).await)
+    }
+}
+
+/// Implement the `wasmcloud:postgres/query` interface for [`PostgresProvider`]
+impl bindings::query::Handler<Option<Context>> for PostgresProvider {
+    #[instrument(level = "debug", skip_all, fields(connection_token, query))]
+    async fn query(
+        &self,
+        _ctx: Option<Context>,
+        connection_token: ConnectionToken,
+        query: String,
+        params: Vec<PgValue>,
+    ) -> Result<Result<Vec<ResultRow>, QueryError>> {
+        Ok(self.do_query(&connection_token, &query, params).await)
+    }
+}
+
+/// Implement the `wasmcloud:postgres/prepared` interface for [`PostgresProvider`]
+impl bindings::prepared::Handler<Option<Context>> for PostgresProvider {
+    #[instrument(level = "debug", skip_all, fields(connection_token, query))]
+    async fn prepare(
+        &self,
+        _ctx: Option<Context>,
+        connection_token: ConnectionToken,
+        query: String,
+    ) -> Result<Result<PreparedStatementToken, StatementPrepareError>> {
+        Ok(self.do_statement_prepare(&connection_token, &query).await)
+    }
+
+    async fn exec(
+        &self,
+        _ctx: Option<Context>,
+        statement_token: PreparedStatementToken,
+        params: Vec<PgValue>,
+    ) -> Result<Result<u64, PreparedStatementExecError>> {
+        Ok(self.do_statement_execute(&statement_token, params).await)
+    }
+}
+
+/// Prefix used for managed connections, normally combined with the source-id of the connection
+const MANAGED_CONNECTION_TOKEN_PREFIX: &str = "managed-";
+/// Generate the token for a managed connection, optionally specialized with a source_id
+pub(crate) fn managed_connection_token_id(source_id: Option<&str>) -> String {
+    match source_id {
+        None => "managed".into(),
+        Some(source_id) => {
+            let source_id = source_id.trim().to_lowercase();
+            format!("{MANAGED_CONNECTION_TOKEN_PREFIX}{source_id}")
+        }
+    }
+}
+
+/// Prefix used for named profile connections, normally combined with the source-id and the profile of the
+/// connection
+const NAMED_PROFILE_CONNECTION_TOKEN_PREFIX: &str = "profile-";
+
+/// Generate the token for a named profile conection, optionally specialized with a source_id
+pub(crate) fn named_profile_connection_token_id(name: &str, source_id: Option<&str>) -> String {
+    let name = name.trim().to_lowercase();
+    match source_id {
+        None => format!("{NAMED_PROFILE_CONNECTION_TOKEN_PREFIX}{name}"),
+        Some(source_id) => {
+            let source_id = source_id.trim().to_lowercase();
+            format!("{NAMED_PROFILE_CONNECTION_TOKEN_PREFIX}{name}-{source_id}")
+        }
+    }
+}
+
+#[cfg(feature = "rustls")]
+fn create_tls_pool(
+    cfg: deadpool_postgres::Config,
+    runtime: Option<deadpool_postgres::Runtime>,
+) -> Result<Pool> {
+    cfg.create_pool(
+        runtime,
+        tokio_postgres_rustls::MakeRustlsConnect::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        ),
+    )
+    .context("failed to create TLS-enabled connection pool")
+}
+
+#[cfg(not(feature = "rustls"))]
+fn create_tls_pool(
+    _cfg: deadpool_postgres::Config,
+    _runtime: Option<deadpool_postgres::Runtime>,
+) -> Result<Pool> {
+    anyhow::bail!("cannot build TLS connections without rustls feature")
+}

--- a/crates/provider-sqldb-postgres/wit/connection.wit
+++ b/crates/provider-sqldb-postgres/wit/connection.wit
@@ -1,0 +1,61 @@
+package wasmcloud:postgres@0.1.0-draft;
+
+/// Manual connection management
+interface connection {
+
+  /// Options for creating a connection to a Postgres instance
+  record connection-create-options {
+    /// Host to connect to
+    host: string, 
+    /// Port
+    port: u16, 
+    /// Username
+    username: string, 
+    /// Password
+    password: string, 
+    /// Database
+    database: string, 
+    /// Require TLS for connections
+    tls-required: bool, 
+  }
+
+  /// To support both managed connections (determined by link configuration)
+  /// and component-driven manual connection management (i.e. this WIT interface)
+  /// we allow connection options to take multiple forms.
+  ///
+  /// By default, connections can be:
+  /// - managed completely by the provider, with the component dealing only in terms of queries
+  /// - component-driven with a named-profile selected by the component
+  /// - component-driven with connection details specified completely by the component
+  variant connection-options {
+    /// Default completely managed connection
+    managed,
+    /// An existing named profile
+    named-profile(string),
+    /// Near-completely dynamic connection creation
+    ///
+    /// NOTE: components probably won't need this, but more dynamic setups might, we can also disable this kind by default at the provider level
+    manual(connection-create-options),
+  }
+
+  /// A token that represents a connection of some sort,
+  /// either a raw database connection or a database session.
+  ///
+  /// This token can be expected to be somewhat opaque to users.
+  type connection-token = string;
+
+  /// Errors that occur when creating a connection
+  variant create-connection-error { 
+    /// Invalid connection options
+    invalid-connection-options(string),
+    /// Failed to connect to the database
+    failed-to-connect(string),
+    /// Invalid authentication
+    invalid-auth(string),
+    /// Completely unexpected error
+    unexpected(string),
+  }
+
+  /// Create a connection
+  create-connection: func(opts: connection-options) -> result<connection-token, create-connection-error>;
+}

--- a/crates/provider-sqldb-postgres/wit/provider.wit
+++ b/crates/provider-sqldb-postgres/wit/provider.wit
@@ -1,0 +1,8 @@
+package wasmcloud:postgres@0.1.0-draft;
+
+world provider-sqldb-postgres {
+    export connection;
+    export managed-query;
+    export query;
+    export prepared;
+}

--- a/crates/provider-sqldb-postgres/wit/query.wit
+++ b/crates/provider-sqldb-postgres/wit/query.wit
@@ -1,0 +1,102 @@
+package wasmcloud:postgres@0.1.0-draft;
+
+/// Interface for querying a Postgres database
+interface query {
+  use types.{pg-value, result-row};
+  use connection.{connection-token};
+
+  /// Errors that occur while executing queries
+  variant query-error {
+    /// Unknown/invalid query parameters
+    invalid-params(string),
+    /// Invalid/malformed query
+    invalid-query(string),
+    /// A completely unexpected error, specific to executing queries
+    unexpected(string),
+  }
+
+  /// Query a Postgres database given a connection token (which can represent a connection *or* session)
+  ///
+  /// Queries *must* be parametrized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  ///
+  /// NOTE: To see how to obtain a `connection-token`, see `connection.wit`.
+  ///
+  query: func(token: connection-token, query: string, params: list<pg-value>) -> result<list<result-row>, query-error>;
+}
+
+/// Managed queries are similar to regular queries, except that clients trust the
+/// provider/implementer to completely manage all connection/session semantics and information.
+///
+/// Connections must be set up and managed out-of-band, completely unknown to the calling component.
+interface managed-query {
+  use types.{pg-value, result-row};
+  use query.{query-error};
+
+  /// Query a Postgres database without a connection token, leaving connection/session management
+  /// to the callee/implementer of this interface
+  ///
+  /// Queries *must* be parametrized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  ///
+  /// NOTE: To see how to obtain a `connection-token`, see `connection.wit`.
+  /// NOTE: If you would like to control the connection/session, see the `query` interface
+  ///
+  query: func(query: string, params: list<pg-value>) -> result<list<result-row>, query-error>;
+}
+
+/// Interface for querying a Postgres database with prepared statements
+interface prepared {
+  use types.{pg-value, result-row};
+  use connection.{connection-token};
+  use query.{query-error};
+
+  /// A token that represents a previously created prepared statement,
+  ///
+  /// This token can be expected to be somewhat opaque to users.
+  type prepared-statement-token = string;
+
+  /// Errors that occur while preparing a statement
+  variant statement-prepare-error {
+    /// A completely unexpected error
+    unexpected(string),
+  }
+
+  /// Errors that occur during prepared statement execution
+  variant prepared-statement-exec-error {
+    /// Unknown/invalid prepared statement token
+    unknown-prepared-query,
+    /// An otherwise known query execution error
+    query-error(query-error),
+    /// A completely unexpected error, specific to prepared statements
+    unexpected(string),
+  }
+
+  /// Prepare a statement, given a connection token (which can represent a connection *or* session),
+  /// to a Postgres database.
+  ///
+  /// Queries *must* be parametrized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  ///
+  /// NOTE: To see how to obtain a `connection-token`, see `connection.wit`.
+  ///
+  prepare: func(
+    token: connection-token,
+    statement: string
+  ) -> result<prepared-statement-token, statement-prepare-error>;
+
+  /// Execute a prepared statement, returning the number of rows affected
+  exec: func(
+    stmt-token: prepared-statement-token,
+    params: list<pg-value>,
+  ) -> result<u64, prepared-statement-exec-error>;
+}

--- a/crates/provider-sqldb-postgres/wit/types.wit
+++ b/crates/provider-sqldb-postgres/wit/types.wit
@@ -1,0 +1,262 @@
+package wasmcloud:postgres@0.1.0-draft;
+
+/// Types used by components and providers of a SQLDB Postgres interface
+interface types {
+  /// This type of floating point is necessary as rust does not allow Eq/PartialEq/Hash on real `f64`
+  /// Instead we use a sign + mantissa + exponent
+  ///
+  /// see: https://docs.rs/num/latest/num/trait.Float.html#tymethod.integer_decode
+  type hashable-f64 = tuple<u64, s16, s8>;
+  type hashable-f32 = hashable-f64;
+
+  type point = tuple<hashable-f64, hashable-f64>;
+  type lower-left-point = point;
+  type upper-right-point = point;
+  type start-point = point;
+  type end-point = point;
+  type center-point = point;
+  type radius = hashable-f64;
+
+  type ipv4-addr = string;
+  type ipv6-addr = string;
+  type subnet = string;
+
+  type xmin = s64;
+  type xmax = s64;
+  type xip-list = list<s64>;
+
+  type logfile-num = u32;
+  type logfile-byte-offset = u32;
+
+  type column-name = string;
+
+  /// Arbitrary precision numeric type
+  type numeric = string;
+
+  /// Chosen weight of a Lexeme
+  enum lexeme-weight {
+    A,
+    B,
+    C,
+    D, // default
+  }
+
+  /// Represents an arbitrary precision numeric type
+  record lexeme {
+    /// Position (1->16383)
+    position: option<u16>,
+    /// Weight of the lexeme (in a relevant ts-vector)
+    weight: option<lexeme-weight>,
+    /// Data
+    data: string,
+  }
+
+  /// Offsets are expressed in seconds of timezone difference in either from the
+  /// eastern hemisphere or western hemisphere.
+  ///
+  /// ex. "America/New York", which is UTC-4 can be expressed as western-hemisphere-secs(4 * 3600)
+  variant offset {
+    eastern-hemisphere-secs(s32),
+    western-hemisphere-secs(s32),
+  }
+
+  /// Dates are represented similarly to tokio-postgres implementation
+  /// see: https://docs.rs/postgres-types/0.2.6/postgres_types/enum.Date.html#variant.Value
+  variant date {
+    positive-infinity,
+    negative-infinity,
+    ymd(tuple<s32, u32, u32>),
+  }
+
+  record interval {
+    start: date,
+    start-inclusive: bool,
+    end: date,
+    end-inclusive: bool,
+  }
+
+  record time {
+    hour: u32,
+    min: u32,
+    sec: u32,
+    micro: u32,
+  }
+
+  record time-tz {
+    timesonze: string,
+    time: time,
+  }
+
+  record timestamp {
+    date: date,
+    time: time,
+  }
+
+  record timestamp-tz {
+    timestamp: timestamp,
+    offset: offset,
+  }
+
+  /// Postgres data values, usable as parameters or via queries
+  /// see: https://www.postgresql.org/docs/current/datatype.html
+  ///
+  /// This datatype is primarily intended to be used with the `raw` encoding scheme.
+  ///
+  /// NOTE: all numeric values are little-endian unless otherwise specified
+  variant pg-value {
+    // Numeric
+    big-int(s64), int8(s64),
+    int8-array(list<s64>),
+
+    big-serial(s64), serial8(s64),
+
+    %bool(bool), boolean(bool),
+    %bool-array(list<bool>),
+
+    double(hashable-f64), float8(hashable-f64),
+    float8-array(list<hashable-f64>),
+
+    real(hashable-f32), float4(hashable-f32),
+    float4-array(list<hashable-f32>),
+
+    integer(s32), int(s32), int4(s32),
+    int4-array(list<s32>),
+
+    numeric(numeric), decimal(numeric),
+    numeric-array(list<numeric>),
+
+    serial(u32), serial4(u32),
+
+    small-int(s16), int2(s16),
+    int2-array(list<s16>),
+    int2-vector(list<s16>),
+    int2-vector-array(list<list<s16>>),
+
+    small-serial(s16), serial2(s16), // note: matches tokio-postgres
+
+    // Bytes
+    //
+    // For bit & bit-varying, see the encoding scheme used by bit-vec:
+    // https://contain-rs.github.io/bit-vec/bit_vec/struct.BitVec.html#method.to_bytes
+    bit(tuple<u32, list<u8>>),
+    bit-array(list<tuple<u32, list<u8>>>),
+    bit-varying(tuple<option<u32>, list<u8>>), varbit(tuple<option<u32>, list<u8>>),
+    varbit-array(list<tuple<option<u32>, list<u8>>>),
+    bytea(list<u8>),
+    bytea-array(list<list<u8>>),
+
+    // Characters
+    // TODO: specify text encoding, to negotiate possible component/DB mismatch?
+    %char(tuple<u32, list<u8>>),
+    %char-array(list<tuple<u32, list<u8>>>),
+
+    varchar(tuple<option<u32>, list<u8>>),
+    varchar-array(list<tuple<option<u32>, list<u8>>>),
+
+    // Networking
+    cidr(string),
+    cidr-array(list<string>),
+
+    inet(string),
+    inet-array(list<string>),
+
+    macaddr(tuple<u8, u8, u8, u8, u8, u8>), // EUI-48
+    macaddr-array(list<tuple<u8, u8, u8, u8, u8, u8>>), // EUI-48
+
+    macaddr8(tuple<u8, u8, u8, u8, u8, u8, u8, u8>), // EUI-64 (deprecated)
+    macaddr8-array(list<tuple<u8, u8, u8, u8, u8, u8, u8, u8>>), // EUI-64 (deprecated)
+
+    // Geo
+    box(tuple<lower-left-point, upper-right-point>),
+    box-array(list<tuple<lower-left-point, upper-right-point>>),
+
+    circle(tuple<center-point, radius>),
+    circle-array(list<tuple<center-point, radius>>),
+
+    line(tuple<start-point, end-point>),
+    line-array(list<tuple<start-point, end-point>>),
+
+    lseg(tuple<start-point, end-point>),
+    lseg-array(list<tuple<start-point, end-point>>),
+
+    path(list<point>),
+    path-array(list<list<point>>),
+
+    point(point),
+    point-array(list<point>),
+
+    polygon(list<point>),
+    polygon-array(list<list<point>>),
+
+    // Date-time
+    date(date),
+    date-array(list<date>),
+
+    interval(interval),
+    interval-array(list<interval>),
+
+    time(time),
+    time-array(list<time>),
+
+    time-tz(time-tz),
+    time-tz-array(list<time-tz>),
+
+    timestamp(timestamp),
+    timestamp-array(list<timestamp>),
+
+    timestamp-tz(timestamp-tz),
+    timestamp-tz-array(list<timestamp-tz>),
+
+    // JSON
+    json(string),
+    json-array(list<string>),
+    jsonb(string),
+    jsonb-array(list<string>),
+
+    // Money (use is discouraged)
+    //
+    // fractional precision is determined by the database's `lc_monetary` setting.
+    //
+    // NOTE: if you are storing currency amounts, consider
+    // using integer (whole number) counts of smallest indivisible pieces of currency
+    // (ex. cent amounts to represent United States Dollars; 100 cents = 1 USD)
+    money(numeric),
+    money-array(list<numeric>),
+
+    // Postgres-internal
+    pg-lsn(u64),
+    pg-lsn-array(list<u64>),
+    // see: https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-PG-SNAPSHOT-PARTS
+    pg-snapshot(tuple<xmin, xmax, xip-list>),
+    txid-snapshot(s64),
+
+    // Text
+    name(string),
+    name-array(list<string>),
+
+    text(string),
+    text-array(list<string>),
+
+    xml(string),
+    xml-array(list<string>),
+
+    // Full Text Search
+    ts-query(string),
+    ts-vector(list<lexeme>),
+
+    // UUIDs
+    uuid(string),
+    uuid-array(list<string>),
+
+    // Containers
+    hstore(list<tuple<string, option<string>>>),
+  }
+
+  record result-row-entry {
+    /// Name of the result column
+    column-name: string,
+    /// Value of the result column
+    value: pg-value,
+  }
+  type result-row = list<result-row-entry>;
+}

--- a/src/bin/keyvalue-redis-provider/wasmcloud.toml
+++ b/src/bin/keyvalue-redis-provider/wasmcloud.toml
@@ -4,7 +4,7 @@ type = "provider"
 version = "0.24.0"
 
 [rust]
-target_path = "../../"
+target_path = "../../target"
 
 [provider]
 bin_name = "keyvalue-redis-provider"

--- a/src/bin/sqldb-postgres-provider/main.rs
+++ b/src/bin/sqldb-postgres-provider/main.rs
@@ -1,0 +1,10 @@
+use anyhow::Context as _;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    wasmcloud_provider_sqldb_postgres::run()
+        .await
+        .context("failed to run provider")?;
+    eprintln!("SQLDB Postgres Provider exiting");
+    Ok(())
+}

--- a/src/bin/sqldb-postgres-provider/wasmcloud.toml
+++ b/src/bin/sqldb-postgres-provider/wasmcloud.toml
@@ -1,11 +1,11 @@
-name = "KV Vault"
+name = "SQLDB Postgres"
 language = "rust"
 type = "provider"
-version = "0.8.0"
+version = "0.1.0"
 
 [rust]
 target_path = "../../target"
 
 [provider]
-bin_name = "keyvalue-vault-provider"
+bin_name = "sqldb-postgres-provider"
 vendor = "wasmCloud"


### PR DESCRIPTION
This commit adds a SQL database provider that supports the widely used, featureful Postgres database system.

One of Postgres's main benefits is a robust type system, and part of the work to make Postges possible to use from the wasmCloud ecosystem involves representing that robust type system in WIT -- see `bindings.rs` for more details.

This provider introduces multiple interfaces for making queries to Postgres cluster -- managed, named profile driven, and completely component-driven connections.