### PR TITLE
refactor(ci): only run provider builds

### DIFF
--- a/.github/workflows/wasmcloud.yml
+++ b/.github/workflows/wasmcloud.yml
@@ -291,6 +291,7 @@ jobs:
           path: doc
 
   providers:
+    if: startswith(github.ref, 'refs/tags/provider-')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This PR ensures providers are built and published only when a tag is pushed that intentionally releases a given provider.

We should still catch breakage of provider crates during normal build, but now we can avoid building them and trying to publish them (or not) on every CI run.